### PR TITLE
fix: Add --v1 flag to oc-mirror list operators commands

### DIFF
--- a/scripts/add-operators-to-imageset.sh
+++ b/scripts/add-operators-to-imageset.sh
@@ -105,7 +105,7 @@ if [ "$ops" -o "$op_sets" ]; then
 			"- Refresh any existing catalog files by running: 'cd $PWD; rm -f .index/redhat-operator-index-v${ocp_ver_major}*' and try again." \
 			"- run 'cd mirror; aba catalog' to try to download the catalog file again." \
 			"- Check that the following command is working:" \
-			"    oc-mirror list operators --catalog registry.redhat.io/redhat/redhat-operator-index:v$ocp_ver_major" \
+			"    oc-mirror --v1 list operators --catalog registry.redhat.io/redhat/redhat-operator-index:v$ocp_ver_major" \
 			"- Check access to registry is working: 'curl -IL http://registry.redhat.io/v2'" 
 		# We want to ensure the user gets what they expect, i.e. operators downloaded! So we abort.
 	fi

--- a/scripts/download-catalog-index-simple.sh
+++ b/scripts/download-catalog-index-simple.sh
@@ -82,10 +82,10 @@ ensure_oc_mirror
 
 # Fetch catalog using oc-mirror
 catalog_url="registry.redhat.io/redhat/${catalog_name}-index:v${ocp_ver_major}"
-aba_info "Running: oc-mirror list operators --catalog $catalog_url"
+aba_info "Running: oc-mirror --v1 list operators --catalog $catalog_url"
 
 # awk '/^NAME/{flag=1; next} flag'  => only used to skip over any unwanted header message
-oc-mirror list operators --catalog "$catalog_url" | awk '/^NAME/{flag=1; next} flag'  > "$index_file"
+oc-mirror --v1 list operators --catalog "$catalog_url" | awk '/^NAME/{flag=1; next} flag'  > "$index_file"
 ret=$?
 
 # Check both exit code AND output file (oc-mirror v2 sometimes returns 0 even on failure)


### PR DESCRIPTION
oc-mirror v2 changed default behavior, requiring the --v1 flag for the list operators subcommand to work correctly.
