### PR TITLE
fix: add --v1 flag to oc-mirror list operators command

### DIFF
--- a/scripts/aba.sh
+++ b/scripts/aba.sh
@@ -5,7 +5,7 @@
 ABA_VERSION="0.9.1"
 
 # Build timestamp (updated by build/pre-commit-checks.sh)
-ABA_BUILD=20260208234722
+ABA_BUILD=20260209173826
 
 # Sanity check build timestamp
 # FIXME: Can only use 'echo' here since can't locate the include_all.sh file yet

--- a/scripts/download-catalog-index-simple.sh
+++ b/scripts/download-catalog-index-simple.sh
@@ -90,11 +90,11 @@ fi
 # Fetch catalog using oc-mirror
 catalog_url="registry.redhat.io/redhat/${catalog_name}-index:v${ocp_ver_major}"
 aba_debug "catalog_url=$catalog_url"
-aba_info "Running: oc-mirror list operators --catalog $catalog_url"
+aba_info "Running: oc-mirror --v1 list operators --catalog $catalog_url"
 
 # awk '/^NAME/{flag=1; next} flag'  => only used to skip over any unwanted header message
 aba_debug "Executing oc-mirror list operators"
-oc-mirror list operators --catalog "$catalog_url" | awk '/^NAME/{flag=1; next} flag'  > "$index_file"
+oc-mirror --v1 list operators --catalog "$catalog_url" | awk '/^NAME/{flag=1; next} flag'  > "$index_file"
 ret=$?
 aba_debug "oc-mirror exit code: $ret"
 


### PR DESCRIPTION
## Description

Re-applies the fix from PR #11 that was inadvertently rolled back in commit 8ca82ae.

oc-mirror v2 requires explicit `--v1` or `--v2` flag. The `list operators` subcommand is only implemented in v1, so `--v1` flag is mandatory.

## Changes

- Added `--v1` flag to `oc-mirror list operators` command in `scripts/download-catalog-index-simple.sh` (line 97)
- Updated info message to reflect the correct command (line 93)

## Error Fixed

```
E0204 13:59:07.778999   52895 main.go:53] ⚠️  the sub-commands 'list', 'describe' and 'init' are only implemented in oc-mirror v1, so please use --v1 for these sub-commands
F0204 13:59:07.779148   52895 main.go:55] ⚠️  the use of the flag --v1 or --v2 is mandatory
```

Fixes #10