### PR TITLE
feat: one-command air-gapped deploy (aba deploy, config import, bundle --complete, waved day2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,13 +75,13 @@ bm:
 .PHONY: tar
 tar:  ## Archive the full repo, e.g. aba tar --out /dev/path/to/thumbdrive. Default output is /tmp/aba-backup.tar. Use --out - to send tar output to stdout. Used by aba bundle.
 	@$(SCRIPTS)/cli-download-all.sh --wait >&2
-	$(SCRIPTS)/backup.sh $(out)
+	$(SCRIPTS)/backup.sh $(complete) $(out)
 
 # Note, the '@' is required for valid tar format output!
 .PHONY: tarrepo
 tarrepo:  ## Archive the repo *excluding* the aba/mirror/mirror_*.tar files. Works in the same way as 'aba tar'.
 	@$(SCRIPTS)/cli-download-all.sh --wait >&2
-	@$(SCRIPTS)/backup.sh --repo $(out)
+	@$(SCRIPTS)/backup.sh --repo $(complete) $(out)
 
 .PHONY: download
 download:  ## Download all required CLI install files without installing. 

--- a/README.md
+++ b/README.md
@@ -924,15 +924,63 @@ spec:
 EOF
 ```
 
+### Ordered waves with readiness gates
+
+When `day2-custom-manifests/` contains numbered subdirectories (names starting with a digit, e.g. `10-first/`, `20-second/`), each is treated as a **wave** and applied in **numeric** order, so `2-...` runs before `10-...` (not alphabetically). Any flat files placed directly in `day2-custom-manifests/` are applied first, before the waves.
+
+Drop an optional `.wait` file into a wave directory to pause until a condition is met before the next wave starts. Each non-comment line is passed straight to `oc wait`:
+
+```bash
+mkdir -p day2-custom-manifests/10-first day2-custom-manifests/20-second
+
+# Wave 10 installs a CRD ...
+cat > day2-custom-manifests/10-first/widget-crd.yaml <<EOF
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  scope: Namespaced
+  names:
+    plural: widgets
+    singular: widget
+    kind: Widget
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+EOF
+
+# ... and we wait for it to be Established before wave 20 creates one
+cat > day2-custom-manifests/10-first/.wait <<EOF
+--for=condition=Established crd/widgets.example.com --timeout=120s
+EOF
+
+cat > day2-custom-manifests/20-second/widget.yaml <<EOF
+apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: my-widget
+  namespace: default
+EOF
+```
+
+A wait that times out is non-fatal: day2 logs a warning and continues with the next wave.
+
 Run `aba day2` as normal — manifests are applied after oc-mirror resources (IDMS, ITMS, CatalogSources, signatures).
 
 #### Notes
 
 - The `day2-custom-manifests/` directory is optional
-- Files are discovered recursively and applied in alphabetical order by full path
-- Use directory naming prefixes (e.g. `00-namespaces/`, `01-app/`) to control order
+- Without numbered subdirectories, files are discovered recursively and applied in alphabetical order by full path
+- With numbered subdirectories (e.g. `10-first/`, `20-second/`), each is a **wave** applied in numeric order; flat top-level files are applied first
+- An optional `.wait` file in a wave directory runs `oc wait` (one condition per line) before the next wave starts
 - Empty files are skipped with a warning
-- If a manifest fails to apply, day2 continues with the remaining files
+- If a manifest fails to apply, or an `oc wait` times out, day2 logs a warning and continues
 - Manifests are applied **after** the mirror registry is configured, so they can reference mirrored images
 
 ## Synchronize NTP Across Cluster Nodes

--- a/README.md
+++ b/README.md
@@ -870,6 +870,29 @@ Configures OpenShift to use your *internal mirror registry* as the source for Op
 
 > **First time?** If you haven't mirrored any operators yet, see [Adding Operators to the Mirror Registry](#adding-operators-to-the-mirror-registry) first.
 
+## One-command air-gapped deploy
+
+`aba deploy` runs the whole disconnected install as one ordered, resumable pipeline:
+
+```
+config import -> mirror install -> mirror load -> iso -> (boot nodes) -> monitor -> day2
+```
+
+Each step is wrapped so re-running `aba deploy` skips already-completed steps and resumes where it stopped; a failed step halts the pipeline so you can fix it and re-run. On bare metal (where aba cannot boot the nodes) deploy pauses after building the ISO - boot the node(s) from the ISO, then re-run `aba deploy` to resume at install monitoring. Hypervisors (vmw/kvm) boot their VMs automatically.
+
+```bash
+# Preview the plan without running anything:
+aba deploy --dry-run
+
+# Run it (auto-detects the single cluster; imports configs from ./site):
+aba deploy
+
+# Or point at a specific config payload and cluster:
+aba deploy --site /path/to/site --cluster mycluster
+```
+
+Deploy imports its configs with `aba config import` (source-agnostic - the configs may come from `aba bundle --complete`, a human, or CI) and applies day2 including any [waved custom manifests](#ordered-waves-with-readiness-gates). Optional settings live in a `deploy.conf` (see `templates/deploy.conf`).
+
 ## Custom Manifests for Day-2
 
 You can automatically apply your own Kubernetes manifests during `aba day2` by placing them in the `day2-custom-manifests/` directory within your cluster folder.

--- a/README.md
+++ b/README.md
@@ -889,6 +889,9 @@ aba deploy
 
 # Or point at a specific config payload and cluster:
 aba deploy --site /path/to/site --cluster mycluster
+
+# Force a fresh re-deploy (clears cached step state, e.g. after tearing a cluster down):
+aba deploy --restart
 ```
 
 Deploy imports its configs with `aba config import` (source-agnostic - the configs may come from `aba bundle --complete`, a human, or CI) and applies day2 including any [waved custom manifests](#ordered-waves-with-readiness-gates). Optional settings live in a `deploy.conf` (see `templates/deploy.conf`).
@@ -949,7 +952,7 @@ EOF
 
 ### Ordered waves with readiness gates
 
-When `day2-custom-manifests/` contains numbered subdirectories (names starting with a digit, e.g. `10-first/`, `20-second/`), each is treated as a **wave** and applied in **numeric** order, so `2-...` runs before `10-...` (not alphabetically). Any flat files placed directly in `day2-custom-manifests/` are applied first, before the waves.
+When `day2-custom-manifests/` contains numbered subdirectories (names starting with a digit, e.g. `10-first/`, `20-second/`), each is treated as a **wave** and applied in **numeric** order, so `2-...` runs before `10-...` (not alphabetically). Any flat files placed directly in `day2-custom-manifests/` are applied at their own sorted position among the waves: a numbered flat file like `05-pre.yaml` runs before `10-first/`, while a non-numbered (letter-named) flat file like `namespace.yaml` sorts after all numbered entries, so it runs after the waves. Prefix a flat file with a number if you need it to run before a given wave.
 
 Drop an optional `.wait` file into a wave directory to pause until a condition is met before the next wave starts. Each non-comment line is passed straight to `oc wait`:
 
@@ -1000,8 +1003,8 @@ Run `aba day2` as normal — manifests are applied after oc-mirror resources (ID
 
 - The `day2-custom-manifests/` directory is optional
 - Without numbered subdirectories, files are discovered recursively and applied in alphabetical order by full path
-- With numbered subdirectories (e.g. `10-first/`, `20-second/`), each is a **wave** applied in numeric order; flat top-level files are applied first
-- An optional `.wait` file in a wave directory runs `oc wait` (one condition per line) before the next wave starts
+- With numbered subdirectories (e.g. `10-first/`, `20-second/`), each is a **wave** applied in numeric order; flat top-level files are applied at their own sorted position among the waves (number-prefix a flat file to run it before a given wave; non-numbered names sort after all waves)
+- An optional `.wait` file in a wave directory runs `oc wait` (one condition per line) before the next wave starts; full-line and trailing `# comments` are ignored, and a line that cannot be parsed (unbalanced quotes) is skipped with a warning
 - Empty files are skipped with a warning
 - If a manifest fails to apply, or an `oc wait` times out, day2 logs a warning and continues
 - Manifests are applied **after** the mirror registry is configured, so they can reference mirrored images

--- a/others/help-aba.txt
+++ b/others/help-aba.txt
@@ -14,6 +14,7 @@ Main commands:
   aba [-d mirror] unregister            # Deregister an existing registry (removes local creds only)
   aba bundle                            # Create a bundle archive file. See 'aba bundle --help'
   aba config import <dir>               # Import prebuilt configs (install-config, agent-config, ISC ...) verbatim
+  aba deploy                            # One-command air-gapped install: config import -> mirror -> iso -> monitor -> day2
   aba cluster                           # Install OpenShift cluster. See 'aba cluster --help'
   aba [-d <cluster>] upgrade --to <ver> # Upgrade a cluster to a target OCP version. See 'aba cluster --help'
 

--- a/others/help-aba.txt
+++ b/others/help-aba.txt
@@ -13,6 +13,7 @@ Main commands:
   aba [-d mirror] register ...          # Register an existing mirror registry (see 'aba mirror --help')
   aba [-d mirror] unregister            # Deregister an existing registry (removes local creds only)
   aba bundle                            # Create a bundle archive file. See 'aba bundle --help'
+  aba config import <dir>               # Import prebuilt configs (install-config, agent-config, ISC ...) verbatim
   aba cluster                           # Install OpenShift cluster. See 'aba cluster --help'
   aba [-d <cluster>] upgrade --to <ver> # Upgrade a cluster to a target OCP version. See 'aba cluster --help'
 

--- a/others/help-aba.txt
+++ b/others/help-aba.txt
@@ -14,7 +14,7 @@ Main commands:
   aba [-d mirror] unregister            # Deregister an existing registry (removes local creds only)
   aba bundle                            # Create a bundle archive file. See 'aba bundle --help'
   aba config import <dir>               # Import prebuilt configs (install-config, agent-config, ISC ...) verbatim
-  aba deploy                            # One-command air-gapped install: config import -> mirror -> iso -> monitor -> day2
+  aba deploy [--dry-run] [--restart]    # One-command air-gapped install (config import -> mirror -> iso -> monitor -> day2). See 'aba deploy --help'
   aba cluster                           # Install OpenShift cluster. See 'aba cluster --help'
   aba [-d <cluster>] upgrade --to <ver> # Upgrade a cluster to a target OCP version. See 'aba cluster --help'
 

--- a/others/help-bundle.txt
+++ b/others/help-bundle.txt
@@ -12,6 +12,9 @@ Usage:
     -f, --force                               # Remove any existing files under mirror/data.
         --light                               # Create *light* bundle, excluding all aba/mirror/data/mirror_*.tar file(s).
                                               # Manual merging of image-set archive file(s) (ISA) required!
+        --complete                            # Embed a site/ config payload (configs, helm charts, day2 manifests)
+                                              # into the bundle so one archive crosses the air gap. Re-apply on the
+                                              # disconnected side with 'aba config import site'.
 
   The 'bundle' command creates an 'install bundle' which is used to install OpenShift in a fully disconnected
   (air-gapped) environment. The 'bundle' command also writes the provided args (channel, version, operators ...)

--- a/others/help-deploy.txt
+++ b/others/help-deploy.txt
@@ -1,0 +1,34 @@
+One-command air-gapped deploy
+
+Usage:
+  aba deploy \
+        --site <dir>                          # Directory of configs to import verbatim (default: ./site).
+        --cluster <name>                      # Cluster directory to build (default: auto-detect the single cluster).
+        --dry-run                             # Print the ordered plan only; execute nothing (no side effects).
+        --restart                             # Clear cached step state for a fresh re-deploy (e.g. after a teardown).
+
+  'aba deploy' runs the whole disconnected install as one ordered, resumable pipeline:
+
+    config import -> mirror install -> mirror load -> iso -> (boot nodes) -> monitor -> day2
+
+  Re-running 'aba deploy' skips already-completed steps and resumes where it stopped; a failed step halts the
+  pipeline so you can fix it and re-run. On bare metal (where aba cannot boot the nodes) deploy pauses after
+  building the ISO - boot the node(s) from the ISO, then re-run 'aba deploy' to resume at install monitoring.
+  Hypervisors (vmw/kvm) boot their VMs automatically.
+
+  Optional settings live in a 'deploy.conf' (sourced key=value, like aba.conf): site_dir and cluster_name.
+  See 'templates/deploy.conf'. The env var 'ABA_DEPLOY_DRY_RUN=1' is equivalent to '--dry-run'.
+
+Examples:
+
+  # Preview the plan without running anything:
+  aba deploy --dry-run
+
+  # Run it (auto-detects the single cluster; imports configs from ./site):
+  aba deploy
+
+  # Point at a specific config payload and cluster:
+  aba deploy --site /path/to/site --cluster mycluster
+
+  # Fresh re-deploy after tearing a cluster down:
+  aba deploy --restart

--- a/scripts/aba.sh
+++ b/scripts/aba.sh
@@ -321,7 +321,7 @@ source <(cd $ABA_ROOT && normalize-aba-conf)
 # Skip for housekeeping commands that never need CLI tools.
 if [ ! "$interactive_mode" ]; then
 	case " $* " in
-		*" clean "*|*" reset "*|*" help "*|*" version "*|*" show-op-sets "*|*" op-sets "*|*" config "*)
+		*" clean "*|*" reset "*|*" help "*|*" version "*|*" show-op-sets "*|*" op-sets "*|*" config "*|*" --dry-run "*)
 			aba_debug "Housekeeping command - skipping early CLI downloads"
 			;;
 		*)

--- a/scripts/aba.sh
+++ b/scripts/aba.sh
@@ -319,7 +319,7 @@ source <(cd $ABA_ROOT && normalize-aba-conf)
 # When ocp_version is unknown, still download version-independent tools
 # (oc-mirror, butane, govc) via --no-version to save time.
 # Skip for housekeeping commands that never need CLI tools.
-if [ ! "$interactive_mode" ]; then
+if [ ! "$interactive_mode" ] && [ -z "$ABA_DEPLOY_DRY_RUN" ]; then
 	case " $* " in
 		*" clean "*|*" reset "*|*" help "*|*" version "*|*" show-op-sets "*|*" op-sets "*|*" config "*|*" --dry-run "*)
 			aba_debug "Housekeeping command - skipping early CLI downloads"
@@ -367,7 +367,14 @@ do
 	# Pass-through subcommands: once 'config' or 'deploy' is the target, hand ALL
 	# remaining args (flags included) to that subcommand instead of parsing here.
 	if [ "$cur_target" = "config" ] || [ "$cur_target" = "deploy" ]; then
-		{ [ "$1" = "-h" ] || [ "$1" = "--help" ]; } && { cat $ABA_ROOT/others/help-aba.txt; exit 0; }
+		if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+			if [ "$cur_target" = "deploy" ] && [ -f "$ABA_ROOT/others/help-deploy.txt" ]; then
+				cat "$ABA_ROOT/others/help-deploy.txt"
+			else
+				cat "$ABA_ROOT/others/help-aba.txt"
+			fi
+			exit 0
+		fi
 		subcmd_args+=("$1")
 		shift
 		continue
@@ -1155,6 +1162,10 @@ if [ "$cur_target" ]; then
 		;;
 		deploy)
 			trap - ERR  # No need for this anymore
+			# A --dry-run placed BEFORE 'deploy' is consumed by the global flag parser
+			# (as upgrade_dry_run), not by the pass-through interception. Forward it so
+			# 'aba --dry-run deploy' previews instead of running a real, side-effecting deploy.
+			[ -n "$upgrade_dry_run" ] && subcmd_args+=(--dry-run)
 			aba_debug "Running: $ABA_ROOT/scripts/deploy.sh ${subcmd_args[*]}"
 			$ABA_ROOT/scripts/deploy.sh "${subcmd_args[@]}"
 			exit

--- a/scripts/aba.sh
+++ b/scripts/aba.sh
@@ -401,6 +401,9 @@ elif [ "$1" = "--light" ]; then
 	export opt_light="--light"  # if "aba bundle", then leave out the image-set archive file(s) from the bundle
 	#BUILD_COMMAND="$BUILD_COMMAND light=light"  # FIXME: Should only allow force=1 after the appropriate target
 	shift
+elif [ "$1" = "--complete" ]; then
+	export opt_complete="--complete"  # if "aba bundle", embed the site/ config payload in the bundle
+	shift
 	elif [ "$1" = "ocp-versions" -o "$1" = "ocp-ver" ]; then
 		shift
 		echo_yellow "Available OpenShift versions:"
@@ -1131,8 +1134,8 @@ if [ "$cur_target" ]; then
 		;;
 		bundle)
 			trap - ERR  # No need for this anymore
-			aba_debug Running: $ABA_ROOT/scripts/make-bundle.sh -o "$opt_out" $opt_force $opt_light
-			eval $ABA_ROOT/scripts/make-bundle.sh $opt_out $opt_force $opt_light
+			aba_debug Running: $ABA_ROOT/scripts/make-bundle.sh -o "$opt_out" $opt_force $opt_light $opt_complete
+			eval $ABA_ROOT/scripts/make-bundle.sh $opt_out $opt_force $opt_light $opt_complete
 			exit
 		;;
 		config)

--- a/scripts/aba.sh
+++ b/scripts/aba.sh
@@ -362,7 +362,16 @@ _set_cluster_conf() {
 while [ "$*" ] 
 do
 	aba_debug "Args: [$@]"
-	aba_debug "BUILD_COMMAND=[$BUILD_COMMAND]" 
+	aba_debug "BUILD_COMMAND=[$BUILD_COMMAND]"
+
+	# Pass-through subcommands: once 'config' or 'deploy' is the target, hand ALL
+	# remaining args (flags included) to that subcommand instead of parsing here.
+	if [ "$cur_target" = "config" ] || [ "$cur_target" = "deploy" ]; then
+		{ [ "$1" = "-h" ] || [ "$1" = "--help" ]; } && { cat $ABA_ROOT/others/help-aba.txt; exit 0; }
+		subcmd_args+=("$1")
+		shift
+		continue
+	fi
 
 	if [ "$1" = "--help" -o "$1" = "-h" ]; then
 		# Peek at next arg if no target yet (allows "aba --help cluster")
@@ -1035,7 +1044,7 @@ elif [ "$1" = "--complete" ]; then
 			cur_target=$1
 
 			case $cur_target in
-				tui|ssh|run|bundle|config|info|login|shell|getco|day2|day2-ntp|day2-osus|upgrade|shutdown|startup|rescue|create|ls|start|stop|kill|poweroff|delete|refresh|upload)
+				tui|ssh|run|bundle|config|deploy|info|login|shell|getco|day2|day2-ntp|day2-osus|upgrade|shutdown|startup|rescue|create|ls|start|stop|kill|poweroff|delete|refresh|upload)
 					# These are processed directly in code below, bypassing Make
 					:
 					;;
@@ -1142,6 +1151,12 @@ if [ "$cur_target" ]; then
 			trap - ERR  # No need for this anymore
 			aba_debug "Running: $ABA_ROOT/scripts/config-import.sh ${subcmd_args[*]}"
 			$ABA_ROOT/scripts/config-import.sh "${subcmd_args[@]}"
+			exit
+		;;
+		deploy)
+			trap - ERR  # No need for this anymore
+			aba_debug "Running: $ABA_ROOT/scripts/deploy.sh ${subcmd_args[*]}"
+			$ABA_ROOT/scripts/deploy.sh "${subcmd_args[@]}"
 			exit
 		;;
 		info)

--- a/scripts/aba.sh
+++ b/scripts/aba.sh
@@ -321,7 +321,7 @@ source <(cd $ABA_ROOT && normalize-aba-conf)
 # Skip for housekeeping commands that never need CLI tools.
 if [ ! "$interactive_mode" ]; then
 	case " $* " in
-		*" clean "*|*" reset "*|*" help "*|*" version "*|*" show-op-sets "*|*" op-sets "*)
+		*" clean "*|*" reset "*|*" help "*|*" version "*|*" show-op-sets "*|*" op-sets "*|*" config "*)
 			aba_debug "Housekeeping command - skipping early CLI downloads"
 			;;
 		*)
@@ -341,6 +341,9 @@ if [ ! "$interactive_mode" ]; then
 fi
 
 cur_target=   # Can be 'cluster', 'mirror', 'save', 'load' etc 
+
+# Positional args for subcommands that parse their own (e.g. 'config import <dir>')
+subcmd_args=()
 
 # Write a cluster-conf variable. If cluster.conf exists, write directly.
 # If the target is 'cluster' (creating a new cluster), forward via BUILD_COMMAND.
@@ -1017,14 +1020,19 @@ elif [ "$1" = "--light" ]; then
 		if echo "$1" | grep -q "^-"; then
 			aba_abort "$(basename $0): Error: no such option $1" 
 		elif [ "$cur_target" ]; then
-			# cur_target already set — additional positionals are make arguments
-			BUILD_COMMAND="$BUILD_COMMAND $1"
-			aba_debug Command added: BUILD_COMMAND=$BUILD_COMMAND
+			# cur_target already set: extra positionals are make args, except for
+			# subcommands that consume their own positional args (config, deploy).
+			if [ "$cur_target" = "config" ] || [ "$cur_target" = "deploy" ]; then
+				subcmd_args+=("$1")
+			else
+				BUILD_COMMAND="$BUILD_COMMAND $1"
+				aba_debug Command added: BUILD_COMMAND=$BUILD_COMMAND
+			fi
 		else
 			cur_target=$1
 
 			case $cur_target in
-				tui|ssh|run|bundle|info|login|shell|getco|day2|day2-ntp|day2-osus|upgrade|shutdown|startup|rescue|create|ls|start|stop|kill|poweroff|delete|refresh|upload)
+				tui|ssh|run|bundle|config|info|login|shell|getco|day2|day2-ntp|day2-osus|upgrade|shutdown|startup|rescue|create|ls|start|stop|kill|poweroff|delete|refresh|upload)
 					# These are processed directly in code below, bypassing Make
 					:
 					;;
@@ -1125,7 +1133,13 @@ if [ "$cur_target" ]; then
 			trap - ERR  # No need for this anymore
 			aba_debug Running: $ABA_ROOT/scripts/make-bundle.sh -o "$opt_out" $opt_force $opt_light
 			eval $ABA_ROOT/scripts/make-bundle.sh $opt_out $opt_force $opt_light
-			exit 
+			exit
+		;;
+		config)
+			trap - ERR  # No need for this anymore
+			aba_debug "Running: $ABA_ROOT/scripts/config-import.sh ${subcmd_args[*]}"
+			$ABA_ROOT/scripts/config-import.sh "${subcmd_args[@]}"
+			exit
 		;;
 		info)
 			$ABA_ROOT/scripts/cluster-info.sh

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -23,13 +23,15 @@ source scripts/include_all.sh
 aba_debug "Starting: $0 $*"
 
 dest=/tmp/aba-backup-$(whoami).tar	# Default file to write to
-inc= 				# Full backup by default (not incremental) 
-repo_only=			# Also include the data/mirror_*.tar files (for some use-cases it's more efficient to keep them separate) 
+inc= 				# Full backup by default (not incremental)
+repo_only=			# Also include the data/mirror_*.tar files (for some use-cases it's more efficient to keep them separate)
+complete=			# Only include the site/ config payload when explicitly requested (aba bundle --complete)
 
 while echo "$1" | grep -q ^--[a-z]
 do
-	[ "$1" = "--repo" ] && repo_only=1 && shift	# Set to NOT include any mirror_*.tar files, which should be copied separately. 
-	[ "$1" = "--inc" ] && inc=1 && shift    	# Set optional backup type to "incremental".  Full is default. 
+	[ "$1" = "--repo" ] && repo_only=1 && shift	# Set to NOT include any mirror_*.tar files, which should be copied separately.
+	[ "$1" = "--inc" ] && inc=1 && shift    	# Set optional backup type to "incremental".  Full is default.
+	[ "$1" = "--complete" ] && complete=1 && shift	# Include the site/ config payload (only 'aba bundle --complete' passes this).
 done
 
 [ "$1" ] && dest="$1"
@@ -78,7 +80,7 @@ rm -f "${repo_dir}/.aba.conf.seen"   # Ensure user can be offered to edit this c
 
 # Include the optional site/ payload (from 'aba bundle --complete') when present.
 _site_path=""
-[ -d "${repo_dir}/site" ] && _site_path="${repo_dir}/site"
+[ "$complete" ] && [ -d "${repo_dir}/site" ] && _site_path="${repo_dir}/site"
 
 # All 'find expr' below are by default "and"
 file_list=$(find				\

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -76,6 +76,10 @@ touch "${repo_dir}/.bundle"
 rm -f "${repo_dir}/.aba.conf.seen"   # Ensure user can be offered to edit this conf file again on the internal/private network
 
 
+# Include the optional site/ payload (from 'aba bundle --complete') when present.
+_site_path=""
+[ -d "${repo_dir}/site" ] && _site_path="${repo_dir}/site"
+
 # All 'find expr' below are by default "and"
 file_list=$(find				\
 	"${repo_dir}/install"			\
@@ -96,6 +100,7 @@ file_list=$(find				\
 	"${repo_dir}/Troubleshooting.md"	\
 	"${repo_dir}/.index"			\
 	"${repo_dir}/mirror"			\
+	${_site_path:+"$_site_path"}		\
 									\
 	! -path "${repo_dir}/.git*"  					\
 	! -path "${repo_dir}/cli/.init"  				\

--- a/scripts/config-import.sh
+++ b/scripts/config-import.sh
@@ -39,7 +39,9 @@ config_import_apply() {
 	_cp_verbatim() {
 		local s="$1" t="$2"
 		mkdir -p "$(dirname "$t")"
-		[ -s "$t" ] && cp -f -- "$t" "$t.backup"
+		# Back up an existing target only ONCE, so re-imports never overwrite the
+		# user's genuine pre-aba original with a previously-imported copy.
+		[ -s "$t" ] && [ ! -e "$t.backup" ] && cp -f -- "$t" "$t.backup"
 		cp -f -- "$s" "$t"
 		aba_info "imported ${t#"$dest"/}"
 	}
@@ -147,6 +149,22 @@ _src="$(cd "$_src" && pwd -P)"
 
 aba_info "Importing configuration from: $_src"
 config_import_apply "$_src" "$PWD"
+
+# Scaffold each imported cluster dir so 'make'/'aba' can operate on it: config
+# import only copies config files, but a working cluster dir also needs the
+# 'Makefile' symlink and the 'scripts'/'templates'/'mirror'/'aba.conf' symlinks
+# that 'make init' creates. Without this, 'make -C <cluster> iso' and day2 fail.
+# Re-assert the install/agent-config mtime pin afterwards, since 'make init' may
+# create the cluster's mirror.conf symlink (a regeneration trigger).
+for _cdir in */; do
+	_cname="${_cdir%/}"
+	case "$_cname" in mirror|site|helm) continue ;; esac
+	[ -f "$_cname/cluster.conf" ] || continue
+	[ -e "$_cname/Makefile" ] || ln -fs ../templates/Makefile.cluster "$_cname/Makefile"
+	make -s -C "$_cname" init >/dev/null 2>&1 || aba_warning "config import: 'make init' for cluster '$_cname' reported an issue (continuing)"
+	[ -f "$_cname/install-config.yaml" ] && touch "$_cname/install-config.yaml"
+	[ -f "$_cname/agent-config.yaml" ]   && touch "$_cname/agent-config.yaml"
+done
 
 # Validate the imported top-level config; fail with a clear error if invalid.
 if [ -f aba.conf ]; then

--- a/scripts/config-import.sh
+++ b/scripts/config-import.sh
@@ -22,6 +22,7 @@
 #
 # USAGE:    aba config import <dir>
 
+_CALLER_PWD="$PWD"   # user's cwd, captured before we cd to the aba root (to resolve a relative <dir>)
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 cd "$SCRIPT_DIR/.." || exit 1
 source scripts/include_all.sh
@@ -36,29 +37,39 @@ config_import_apply() {
 	[ -n "$dest" ] || aba_abort "config import: no destination aba root given"
 
 	# Copy a file byte-for-byte, creating parent dirs and backing up any existing target.
+	# Every mutation is checked so a failed copy aborts loudly instead of reporting success.
 	_cp_verbatim() {
 		local s="$1" t="$2"
-		mkdir -p "$(dirname "$t")"
+		mkdir -p "$(dirname "$t")" || aba_abort "config import: cannot create directory for ${t#"$dest"/}"
 		# Back up an existing target only ONCE, so re-imports never overwrite the
 		# user's genuine pre-aba original with a previously-imported copy.
-		[ -s "$t" ] && [ ! -e "$t.backup" ] && cp -f -- "$t" "$t.backup"
-		cp -f -- "$s" "$t"
+		[ -s "$t" ] && [ ! -e "$t.backup" ] && { cp -f -- "$t" "$t.backup" || aba_abort "config import: cannot back up ${t#"$dest"/}"; }
+		cp -f -- "$s" "$t" || aba_abort "config import: failed to copy '$s' -> ${t#"$dest"/}"
 		aba_info "imported ${t#"$dest"/}"
 	}
 
-	local copied=0 f d name imported=""
+	local copied=0 f d name imported="" _did_mirror_conf="" _did_isc=""
 
 	# Replace a directory payload byte-for-byte, backing up any existing target to
 	# *.backup first (mirrors _cp_verbatim's backup behavior for files).
 	_cp_dir_verbatim() {
 		local s="$1" t="$2"
-		mkdir -p "$(dirname "$t")"
+		mkdir -p "$(dirname "$t")" || aba_abort "config import: cannot create directory for ${t#"$dest"/}"
 		if [ -e "$t" ]; then
 			# Back up the original ONCE; later re-imports must not clobber it.
-			if [ -e "$t.backup" ]; then rm -rf -- "$t"; else mv -- "$t" "$t.backup"; fi
+			if [ -e "$t.backup" ]; then rm -rf -- "$t"; else mv -- "$t" "$t.backup" || aba_abort "config import: cannot back up ${t#"$dest"/}"; fi
 		fi
-		cp -a -- "$s" "$t"
+		cp -a -- "$s" "$t" || aba_abort "config import: failed to copy '$s' -> ${t#"$dest"/}"
 	}
+
+	# Validate ALL cluster-dir names up front, before copying anything, so a bad or
+	# reserved name aborts while the tree is still untouched (no half-import).
+	for d in "$src"/*/; do
+		[ -d "$d" ] || continue
+		name="$(basename "$d")"
+		case "$name" in mirror|helm) continue ;; esac
+		_valid_cluster_name "$name" >/dev/null 2>&1 || aba_abort "config import: invalid or reserved cluster directory name '$name' in the site payload"
+	done
 
 	# Top-level aba configs
 	for f in aba.conf vmware.conf kvm.conf; do
@@ -71,31 +82,38 @@ config_import_apply() {
 	# Mirror configs
 	if [ -f "$src/mirror/mirror.conf" ]; then
 		_cp_verbatim "$src/mirror/mirror.conf" "$dest/mirror/mirror.conf"
-		copied=$((copied + 1))
+		copied=$((copied + 1)); _did_mirror_conf=1
 	fi
 	if [ -f "$src/mirror/imageset-config.yaml" ]; then
 		_cp_verbatim "$src/mirror/imageset-config.yaml" "$dest/mirror/data/imageset-config.yaml"
-		copied=$((copied + 1))
+		copied=$((copied + 1)); _did_isc=1
 	fi
 
-	# Per-cluster configs: every subdir of the site except mirror/ and helm/
+	# Per-cluster configs: every subdir of the site except mirror/ and helm/ (names
+	# were validated in the pre-pass above).
 	for d in "$src"/*/; do
 		[ -d "$d" ] || continue
 		name="$(basename "$d")"
 		case "$name" in mirror|helm) continue ;; esac
-		# Reject reserved/invalid names so a malformed payload cannot write into
-		# reserved repo dirs (scripts/, templates/, ...) via a planted cluster.conf.
-		_valid_cluster_name "$name" >/dev/null 2>&1 || aba_abort "config import: invalid or reserved cluster directory name '$name' in the site payload"
-		[ -f "$d/cluster.conf" ]        && { _cp_verbatim "$d/cluster.conf"        "$dest/$name/cluster.conf";        copied=$((copied + 1)); }
-		[ -f "$d/install-config.yaml" ] && { _cp_verbatim "$d/install-config.yaml" "$dest/$name/install-config.yaml"; copied=$((copied + 1)); }
-		[ -f "$d/agent-config.yaml" ]   && { _cp_verbatim "$d/agent-config.yaml"   "$dest/$name/agent-config.yaml";   copied=$((copied + 1)); }
-		[ -f "$d/macs.conf" ]           && { _cp_verbatim "$d/macs.conf"           "$dest/$name/macs.conf";           copied=$((copied + 1)); }
-		[ -d "$d/day2-custom-manifests" ] && { _cp_dir_verbatim "$d/day2-custom-manifests" "$dest/$name/day2-custom-manifests"; copied=$((copied + 1)); }
-		imported="$imported $name"
+		local _n=0
+		[ -f "$d/cluster.conf" ]        && { _cp_verbatim "$d/cluster.conf"        "$dest/$name/cluster.conf";        copied=$((copied + 1)); _n=$((_n + 1)); }
+		[ -f "$d/install-config.yaml" ] && { _cp_verbatim "$d/install-config.yaml" "$dest/$name/install-config.yaml"; copied=$((copied + 1)); _n=$((_n + 1)); }
+		[ -f "$d/agent-config.yaml" ]   && { _cp_verbatim "$d/agent-config.yaml"   "$dest/$name/agent-config.yaml";   copied=$((copied + 1)); _n=$((_n + 1)); }
+		[ -f "$d/macs.conf" ]           && { _cp_verbatim "$d/macs.conf"           "$dest/$name/macs.conf";           copied=$((copied + 1)); _n=$((_n + 1)); }
+		[ -d "$d/day2-custom-manifests" ] && { _cp_dir_verbatim "$d/day2-custom-manifests" "$dest/$name/day2-custom-manifests"; copied=$((copied + 1)); _n=$((_n + 1)); }
+		# The site layout carries a single mirror/ payload, so a cluster wired to a
+		# non-default mirror_name would look elsewhere and ignore it - warn clearly.
+		if [ -f "$d/cluster.conf" ]; then
+			local _mn; _mn="$(grep '^mirror_name=' "$d/cluster.conf" 2>/dev/null | head -1 | cut -d= -f2 | awk '{print $1}')"
+			[ -n "$_mn" ] && [ "$_mn" != "mirror" ] && aba_warning "config import: cluster '$name' sets mirror_name='$_mn'; the site layout carries a single 'mirror/' payload, so this cluster may not use the imported mirror config."
+		fi
+		# Only record this cluster as imported when at least one file was actually copied,
+		# so the pins/scaffold below never mutate a same-named pre-existing cluster.
+		[ "$_n" -gt 0 ] && imported="$imported $name"
 	done
 
 	# Optional helm charts payload (opaque passthrough, no regeneration guard)
-	[ -d "$src/helm" ] && _cp_dir_verbatim "$src/helm" "$dest/helm"
+	[ -d "$src/helm" ] && { _cp_dir_verbatim "$src/helm" "$dest/helm"; copied=$((copied + 1)); }
 
 	[ "$copied" -gt 0 ] || aba_abort "config import: no recognized config files found under $src"
 
@@ -115,24 +133,28 @@ config_import_apply() {
 	}
 
 	# ISC: reg-create-imageset-config.sh regenerates unless imageset-config.yaml is
-	# strictly newer than data/.created - so keep the imported ISC pinned. .created
-	# must exist for the guard, so create it (empty marker) before aging it.
-	if [ -f "$dest/mirror/data/imageset-config.yaml" ]; then
+	# strictly newer than data/.created - so keep the imported ISC pinned, but ONLY when
+	# it was actually imported this run (never re-pin a pre-existing generated ISC).
+	# .created must exist for the guard, so create it (empty marker) before aging it.
+	if [ -n "$_did_isc" ] && [ -f "$dest/mirror/data/imageset-config.yaml" ]; then
 		[ -f "$dest/mirror/data/.created" ] || : > "$dest/mirror/data/.created"
 		_age_past "$dest/mirror/data/.created"
 		touch "$dest/mirror/data/imageset-config.yaml"
 	fi
 
 	# install-config.yaml / agent-config.yaml: make regenerates them if they are older
-	# than their prerequisites cluster.conf or mirror.conf - so keep them newest. Scope
-	# strictly to the clusters imported this run (never mutate other clusters' state).
+	# than their prerequisites cluster.conf or mirror.conf - so keep the IMPORTED ones
+	# newest. Gate every touch on what was copied THIS run (checked against $src), so a
+	# partial payload never rewinds or re-pins a user's own pre-existing files.
 	for name in $imported; do
-		d="$dest/$name"
-		if [ -f "$d/install-config.yaml" ] || [ -f "$d/agent-config.yaml" ]; then
-			_age_past "$d/cluster.conf"
-			_age_past "$dest/mirror/mirror.conf"
-			[ -f "$d/install-config.yaml" ] && touch "$d/install-config.yaml"
-			[ -f "$d/agent-config.yaml" ]   && touch "$d/agent-config.yaml"
+		d="$dest/$name"; s="$src/$name"
+		if [ -f "$s/install-config.yaml" ] || [ -f "$s/agent-config.yaml" ]; then
+			# Age a trigger only if IT was imported too; a non-imported cluster.conf or
+			# mirror.conf is already older than the just-copied protected file.
+			[ -f "$s/cluster.conf" ] && _age_past "$d/cluster.conf"
+			[ -n "$_did_mirror_conf" ] && _age_past "$dest/mirror/mirror.conf"
+			[ -f "$s/install-config.yaml" ] && touch "$d/install-config.yaml"
+			[ -f "$s/agent-config.yaml" ]   && touch "$d/agent-config.yaml"
 		fi
 	done
 
@@ -148,6 +170,8 @@ _verb=""
 
 _src="$1"
 [ -n "$_src" ] || aba_abort "Usage: aba config import <dir>" "Imports configs from <dir> into this aba installation (source-agnostic; files are used verbatim)."
+# Resolve a relative <dir> against the user's original cwd, not the aba root we cd'd to.
+case "$_src" in /*) ;; *) _src="$_CALLER_PWD/$_src" ;; esac
 [ -d "$_src" ] || aba_abort "config import: source directory not found: $_src"
 _src="$(cd "$_src" && pwd -P)"
 
@@ -158,12 +182,19 @@ config_import_apply "$_src" "$PWD"
 # import only copies config files, but a working cluster dir also needs the
 # 'Makefile' symlink and the 'scripts'/'templates'/'mirror'/'aba.conf' symlinks
 # that 'make init' creates. Without this, 'make -C <cluster> iso' and day2 fail.
-# Re-assert the install/agent-config mtime pin afterwards, since 'make init' may
-# create the cluster's mirror.conf symlink (a regeneration trigger).
+# Re-assert the mtime pins afterwards: 'make init' creates a fresh '.init' marker
+# (mtime now), and '.init' is a NORMAL prerequisite of cluster.conf in
+# templates/Makefile.cluster ('cluster.conf: .init | mirror.conf'). Since
+# config_import_apply aged cluster.conf into the past, an un-pinned cluster.conf
+# would be older than '.init', so the next 'make ... iso' would re-run
+# create-cluster-conf.sh and then re-template the imported install/agent-config.
+# Touch cluster.conf, then install/agent-config, in that order so each stays
+# newest-in-turn (make only rebuilds on a STRICTLY newer prerequisite).
 for _cname in $_IMPORTED_CLUSTERS; do
 	[ -f "$_cname/cluster.conf" ] || continue
 	[ -e "$_cname/Makefile" ] || ln -fs ../templates/Makefile.cluster "$_cname/Makefile"
 	make -s -C "$_cname" init >/dev/null 2>&1 || aba_warning "config import: 'make init' for cluster '$_cname' reported an issue (continuing)"
+	touch "$_cname/cluster.conf"
 	[ -f "$_cname/install-config.yaml" ] && touch "$_cname/install-config.yaml"
 	[ -f "$_cname/agent-config.yaml" ]   && touch "$_cname/agent-config.yaml"
 done

--- a/scripts/config-import.sh
+++ b/scripts/config-import.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# config-import.sh -- Import a "site" config payload into this aba tree, VERBATIM.
+#
+# INTENT:   Take a directory of pre-built aba configs (produced by anything: a
+#           generator, a human, CI - aba does not care) and place each file at its
+#           correct path in this aba installation, byte-for-byte, then pin the
+#           regeneration guards so aba never re-templates over the imported files.
+#           This is the "bring your own configs" path used by 'aba deploy'.
+#
+# LAYOUT (source-agnostic convention; every path is optional):
+#   <dir>/aba.conf                              -> aba.conf
+#   <dir>/vmware.conf | kvm.conf                -> vmware.conf | kvm.conf
+#   <dir>/mirror/mirror.conf                    -> mirror/mirror.conf
+#   <dir>/mirror/imageset-config.yaml           -> mirror/data/imageset-config.yaml
+#   <dir>/<cluster>/cluster.conf                -> <cluster>/cluster.conf
+#   <dir>/<cluster>/install-config.yaml         -> <cluster>/install-config.yaml
+#   <dir>/<cluster>/agent-config.yaml           -> <cluster>/agent-config.yaml
+#   <dir>/<cluster>/macs.conf                   -> <cluster>/macs.conf
+#   <dir>/<cluster>/day2-custom-manifests/...   -> <cluster>/day2-custom-manifests/...
+#   <dir>/helm/...                              -> helm/... (opaque passthrough)
+#   (any subdir other than mirror/ or helm/ is treated as a cluster directory)
+#
+# USAGE:    aba config import <dir>
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+cd "$SCRIPT_DIR/.." || exit 1
+source scripts/include_all.sh
+
+# config_import_apply <src_site_dir> <dest_aba_root>
+# Copy recognized configs from the site layout into the aba tree byte-for-byte,
+# backing up any existing target to *.backup, then pin regeneration guards.
+config_import_apply() {
+	local src="$1" dest="$2"
+
+	{ [ -n "$src" ] && [ -d "$src" ]; } || aba_abort "config import: source directory not found: ${src:-<none>}"
+	[ -n "$dest" ] || aba_abort "config import: no destination aba root given"
+
+	# Copy a file byte-for-byte, creating parent dirs and backing up any existing target.
+	_cp_verbatim() {
+		local s="$1" t="$2"
+		mkdir -p "$(dirname "$t")"
+		[ -s "$t" ] && cp -f -- "$t" "$t.backup"
+		cp -f -- "$s" "$t"
+		aba_info "imported ${t#"$dest"/}"
+	}
+
+	local copied=0 f d name
+
+	# Top-level aba configs
+	for f in aba.conf vmware.conf kvm.conf; do
+		if [ -f "$src/$f" ]; then
+			_cp_verbatim "$src/$f" "$dest/$f"
+			copied=$((copied + 1))
+		fi
+	done
+
+	# Mirror configs
+	if [ -f "$src/mirror/mirror.conf" ]; then
+		_cp_verbatim "$src/mirror/mirror.conf" "$dest/mirror/mirror.conf"
+		copied=$((copied + 1))
+	fi
+	if [ -f "$src/mirror/imageset-config.yaml" ]; then
+		_cp_verbatim "$src/mirror/imageset-config.yaml" "$dest/mirror/data/imageset-config.yaml"
+		copied=$((copied + 1))
+	fi
+
+	# Per-cluster configs: every subdir of the site except mirror/ and helm/
+	for d in "$src"/*/; do
+		[ -d "$d" ] || continue
+		name="$(basename "$d")"
+		case "$name" in mirror|helm) continue ;; esac
+		[ -f "$d/cluster.conf" ]        && { _cp_verbatim "$d/cluster.conf"        "$dest/$name/cluster.conf";        copied=$((copied + 1)); }
+		[ -f "$d/install-config.yaml" ] && { _cp_verbatim "$d/install-config.yaml" "$dest/$name/install-config.yaml"; copied=$((copied + 1)); }
+		[ -f "$d/agent-config.yaml" ]   && { _cp_verbatim "$d/agent-config.yaml"   "$dest/$name/agent-config.yaml";   copied=$((copied + 1)); }
+		[ -f "$d/macs.conf" ]           && { _cp_verbatim "$d/macs.conf"           "$dest/$name/macs.conf";           copied=$((copied + 1)); }
+		if [ -d "$d/day2-custom-manifests" ]; then
+			mkdir -p "$dest/$name"
+			rm -rf -- "$dest/$name/day2-custom-manifests"
+			cp -a -- "$d/day2-custom-manifests" "$dest/$name/day2-custom-manifests"
+			copied=$((copied + 1))
+		fi
+	done
+
+	# Optional helm charts payload (opaque passthrough, no regeneration guard)
+	if [ -d "$src/helm" ]; then
+		rm -rf -- "$dest/helm"
+		cp -a -- "$src/helm" "$dest/helm"
+	fi
+
+	[ "$copied" -gt 0 ] || aba_abort "config import: no recognized config files found under $src"
+
+	# --- pin regeneration guards ---------------------------------------------
+	# Every copy above has an mtime of 'now'. On filesystems with second-level
+	# mtime granularity, "protected file newer than trigger" is not guaranteed by
+	# copy order alone, so we age the TRIGGER files by a minute and re-stamp the
+	# PROTECTED files to 'now', making the strict "-nt" guards deterministic.
+
+	# ISC: reg-create-imageset-config.sh regenerates unless imageset-config.yaml
+	# is strictly newer than data/.created - so keep the imported ISC pinned.
+	if [ -f "$dest/mirror/data/imageset-config.yaml" ]; then
+		touch -d '1 minute ago' "$dest/mirror/data/.created" 2>/dev/null || : > "$dest/mirror/data/.created"
+		touch "$dest/mirror/data/imageset-config.yaml"
+	fi
+
+	# install-config.yaml / agent-config.yaml: make regenerates them if they are
+	# older than their prerequisites cluster.conf or mirror.conf - so keep them newest.
+	for d in "$dest"/*/; do
+		[ -d "$d" ] || continue
+		name="$(basename "$d")"
+		case "$name" in mirror|helm) continue ;; esac
+		if [ -f "$d/install-config.yaml" ] || [ -f "$d/agent-config.yaml" ]; then
+			touch -d '1 minute ago' "$d/cluster.conf" "$dest/mirror/mirror.conf" 2>/dev/null || true
+			[ -f "$d/install-config.yaml" ] && touch "$d/install-config.yaml"
+			[ -f "$d/agent-config.yaml" ]   && touch "$d/agent-config.yaml"
+		fi
+	done
+
+	return 0
+}
+
+# ---- run (the unit test extracts config_import_apply and never reaches here) --
+aba_debug "Starting: $0 $*"
+
+_verb=""
+[ "$1" = "import" ] && { _verb="import"; shift; }
+
+_src="$1"
+[ -n "$_src" ] || aba_abort "Usage: aba config import <dir>" "Imports configs from <dir> into this aba installation (source-agnostic; files are used verbatim)."
+[ -d "$_src" ] || aba_abort "config import: source directory not found: $_src"
+_src="$(cd "$_src" && pwd -P)"
+
+aba_info "Importing configuration from: $_src"
+config_import_apply "$_src" "$PWD"
+
+# Validate the imported top-level config; fail with a clear error if invalid.
+if [ -f aba.conf ]; then
+	source <(normalize-aba-conf)
+	verify-aba-conf || aba_abort "$_ABA_CONF_ERR"
+fi
+
+aba_info_ok "Configuration imported. aba will use these files verbatim (no re-templating)."

--- a/scripts/config-import.sh
+++ b/scripts/config-import.sh
@@ -54,8 +54,8 @@ config_import_apply() {
 		local s="$1" t="$2"
 		mkdir -p "$(dirname "$t")"
 		if [ -e "$t" ]; then
-			rm -rf -- "$t.backup"
-			mv -- "$t" "$t.backup"
+			# Back up the original ONCE; later re-imports must not clobber it.
+			if [ -e "$t.backup" ]; then rm -rf -- "$t"; else mv -- "$t" "$t.backup"; fi
 		fi
 		cp -a -- "$s" "$t"
 	}
@@ -83,6 +83,9 @@ config_import_apply() {
 		[ -d "$d" ] || continue
 		name="$(basename "$d")"
 		case "$name" in mirror|helm) continue ;; esac
+		# Reject reserved/invalid names so a malformed payload cannot write into
+		# reserved repo dirs (scripts/, templates/, ...) via a planted cluster.conf.
+		_valid_cluster_name "$name" >/dev/null 2>&1 || aba_abort "config import: invalid or reserved cluster directory name '$name' in the site payload"
 		[ -f "$d/cluster.conf" ]        && { _cp_verbatim "$d/cluster.conf"        "$dest/$name/cluster.conf";        copied=$((copied + 1)); }
 		[ -f "$d/install-config.yaml" ] && { _cp_verbatim "$d/install-config.yaml" "$dest/$name/install-config.yaml"; copied=$((copied + 1)); }
 		[ -f "$d/agent-config.yaml" ]   && { _cp_verbatim "$d/agent-config.yaml"   "$dest/$name/agent-config.yaml";   copied=$((copied + 1)); }
@@ -133,6 +136,7 @@ config_import_apply() {
 		fi
 	done
 
+	_IMPORTED_CLUSTERS="$imported"   # expose to the caller so scaffolding touches only these
 	return 0
 }
 
@@ -156,9 +160,7 @@ config_import_apply "$_src" "$PWD"
 # that 'make init' creates. Without this, 'make -C <cluster> iso' and day2 fail.
 # Re-assert the install/agent-config mtime pin afterwards, since 'make init' may
 # create the cluster's mirror.conf symlink (a regeneration trigger).
-for _cdir in */; do
-	_cname="${_cdir%/}"
-	case "$_cname" in mirror|site|helm) continue ;; esac
+for _cname in $_IMPORTED_CLUSTERS; do
 	[ -f "$_cname/cluster.conf" ] || continue
 	[ -e "$_cname/Makefile" ] || ln -fs ../templates/Makefile.cluster "$_cname/Makefile"
 	make -s -C "$_cname" init >/dev/null 2>&1 || aba_warning "config import: 'make init' for cluster '$_cname' reported an issue (continuing)"

--- a/scripts/config-import.sh
+++ b/scripts/config-import.sh
@@ -44,7 +44,19 @@ config_import_apply() {
 		aba_info "imported ${t#"$dest"/}"
 	}
 
-	local copied=0 f d name
+	local copied=0 f d name imported=""
+
+	# Replace a directory payload byte-for-byte, backing up any existing target to
+	# *.backup first (mirrors _cp_verbatim's backup behavior for files).
+	_cp_dir_verbatim() {
+		local s="$1" t="$2"
+		mkdir -p "$(dirname "$t")"
+		if [ -e "$t" ]; then
+			rm -rf -- "$t.backup"
+			mv -- "$t" "$t.backup"
+		fi
+		cp -a -- "$s" "$t"
+	}
 
 	# Top-level aba configs
 	for f in aba.conf vmware.conf kvm.conf; do
@@ -73,43 +85,47 @@ config_import_apply() {
 		[ -f "$d/install-config.yaml" ] && { _cp_verbatim "$d/install-config.yaml" "$dest/$name/install-config.yaml"; copied=$((copied + 1)); }
 		[ -f "$d/agent-config.yaml" ]   && { _cp_verbatim "$d/agent-config.yaml"   "$dest/$name/agent-config.yaml";   copied=$((copied + 1)); }
 		[ -f "$d/macs.conf" ]           && { _cp_verbatim "$d/macs.conf"           "$dest/$name/macs.conf";           copied=$((copied + 1)); }
-		if [ -d "$d/day2-custom-manifests" ]; then
-			mkdir -p "$dest/$name"
-			rm -rf -- "$dest/$name/day2-custom-manifests"
-			cp -a -- "$d/day2-custom-manifests" "$dest/$name/day2-custom-manifests"
-			copied=$((copied + 1))
-		fi
+		[ -d "$d/day2-custom-manifests" ] && { _cp_dir_verbatim "$d/day2-custom-manifests" "$dest/$name/day2-custom-manifests"; copied=$((copied + 1)); }
+		imported="$imported $name"
 	done
 
 	# Optional helm charts payload (opaque passthrough, no regeneration guard)
-	if [ -d "$src/helm" ]; then
-		rm -rf -- "$dest/helm"
-		cp -a -- "$src/helm" "$dest/helm"
-	fi
+	[ -d "$src/helm" ] && _cp_dir_verbatim "$src/helm" "$dest/helm"
 
 	[ "$copied" -gt 0 ] || aba_abort "config import: no recognized config files found under $src"
 
 	# --- pin regeneration guards ---------------------------------------------
-	# Every copy above has an mtime of 'now'. On filesystems with second-level
-	# mtime granularity, "protected file newer than trigger" is not guaranteed by
-	# copy order alone, so we age the TRIGGER files by a minute and re-stamp the
-	# PROTECTED files to 'now', making the strict "-nt" guards deterministic.
+	# Every copy above has an mtime of 'now'. On second-granularity filesystems,
+	# "protected file newer than trigger" is not guaranteed by copy order alone, so
+	# we age the TRIGGER files ~1 minute and re-stamp the PROTECTED files to 'now'.
+	# Only files imported this run are touched, and no absent file is created.
 
-	# ISC: reg-create-imageset-config.sh regenerates unless imageset-config.yaml
-	# is strictly newer than data/.created - so keep the imported ISC pinned.
+	# Best-effort: age an EXISTING file ~1 minute into the past (portable, no-create).
+	_age_past() {
+		touch -c -d '1 minute ago' "$1" 2>/dev/null && return 0
+		local ts
+		ts="$(date -d '1 minute ago' +%Y%m%d%H%M.%S 2>/dev/null || date -v-1M +%Y%m%d%H%M.%S 2>/dev/null || true)"
+		[ -n "$ts" ] && touch -c -t "$ts" "$1" 2>/dev/null
+		return 0
+	}
+
+	# ISC: reg-create-imageset-config.sh regenerates unless imageset-config.yaml is
+	# strictly newer than data/.created - so keep the imported ISC pinned. .created
+	# must exist for the guard, so create it (empty marker) before aging it.
 	if [ -f "$dest/mirror/data/imageset-config.yaml" ]; then
-		touch -d '1 minute ago' "$dest/mirror/data/.created" 2>/dev/null || : > "$dest/mirror/data/.created"
+		[ -f "$dest/mirror/data/.created" ] || : > "$dest/mirror/data/.created"
+		_age_past "$dest/mirror/data/.created"
 		touch "$dest/mirror/data/imageset-config.yaml"
 	fi
 
-	# install-config.yaml / agent-config.yaml: make regenerates them if they are
-	# older than their prerequisites cluster.conf or mirror.conf - so keep them newest.
-	for d in "$dest"/*/; do
-		[ -d "$d" ] || continue
-		name="$(basename "$d")"
-		case "$name" in mirror|helm) continue ;; esac
+	# install-config.yaml / agent-config.yaml: make regenerates them if they are older
+	# than their prerequisites cluster.conf or mirror.conf - so keep them newest. Scope
+	# strictly to the clusters imported this run (never mutate other clusters' state).
+	for name in $imported; do
+		d="$dest/$name"
 		if [ -f "$d/install-config.yaml" ] || [ -f "$d/agent-config.yaml" ]; then
-			touch -d '1 minute ago' "$d/cluster.conf" "$dest/mirror/mirror.conf" 2>/dev/null || true
+			_age_past "$d/cluster.conf"
+			_age_past "$dest/mirror/mirror.conf"
 			[ -f "$d/install-config.yaml" ] && touch "$d/install-config.yaml"
 			[ -f "$d/agent-config.yaml" ]   && touch "$d/agent-config.yaml"
 		fi

--- a/scripts/config-import.sh
+++ b/scripts/config-import.sh
@@ -188,15 +188,17 @@ config_import_apply "$_src" "$PWD"
 # config_import_apply aged cluster.conf into the past, an un-pinned cluster.conf
 # would be older than '.init', so the next 'make ... iso' would re-run
 # create-cluster-conf.sh and then re-template the imported install/agent-config.
-# Touch cluster.conf, then install/agent-config, in that order so each stays
-# newest-in-turn (make only rebuilds on a STRICTLY newer prerequisite).
+# Pin ONLY the files imported verbatim THIS run (checked against $_src), in
+# cluster.conf -> install/agent order so each stays newest-in-turn (make rebuilds
+# only on a STRICTLY newer prerequisite). Files NOT imported are left alone so make
+# can still (re)generate them - e.g. install-config after a cluster.conf-only import.
 for _cname in $_IMPORTED_CLUSTERS; do
 	[ -f "$_cname/cluster.conf" ] || continue
 	[ -e "$_cname/Makefile" ] || ln -fs ../templates/Makefile.cluster "$_cname/Makefile"
 	make -s -C "$_cname" init >/dev/null 2>&1 || aba_warning "config import: 'make init' for cluster '$_cname' reported an issue (continuing)"
-	touch "$_cname/cluster.conf"
-	[ -f "$_cname/install-config.yaml" ] && touch "$_cname/install-config.yaml"
-	[ -f "$_cname/agent-config.yaml" ]   && touch "$_cname/agent-config.yaml"
+	[ -f "$_src/$_cname/cluster.conf" ]        && touch "$_cname/cluster.conf"
+	[ -f "$_src/$_cname/install-config.yaml" ] && touch "$_cname/install-config.yaml"
+	[ -f "$_src/$_cname/agent-config.yaml" ]   && touch "$_cname/agent-config.yaml"
 done
 
 # Validate the imported top-level config; fail with a clear error if invalid.

--- a/scripts/day2.sh
+++ b/scripts/day2.sh
@@ -256,13 +256,24 @@ apply_custom_manifests() {
 
 			# Optional gate on a wave dir: one 'oc wait' condition per non-comment line
 			# in '.wait'. A failed/timed-out wait is non-fatal so day2 can continue.
-			if [ -d "$entry" ] && [ -f "$entry/.wait" ]; then
+			# Require -r too: day2 runs under 'set -e', so an unreadable '.wait' would
+			# make the loop's input redirect fail and abort the whole day2 run.
+			if [ -d "$entry" ] && [ -f "$entry/.wait" ] && [ ! -r "$entry/.wait" ]; then
+				aba_warning "Wave $entry_name: '.wait' exists but is not readable (skipping gate, continuing)"
+			elif [ -d "$entry" ] && [ -f "$entry/.wait" ]; then
 				while IFS= read -r _cond || [ -n "$_cond" ]; do
 					_cond="${_cond%$'\r'}"
 					_cond="${_cond#"${_cond%%[![:space:]]*}"}"   # trim leading whitespace
+					case "$_cond" in \#*) continue ;; esac         # skip full-line comments first
+					_cond="${_cond%% #*}"                          # strip an unquoted trailing ' # comment'
 					_cond="${_cond%"${_cond##*[![:space:]]}"}"   # trim trailing whitespace
 					[ -z "$_cond" ] && continue
-					case "$_cond" in \#*) continue ;; esac
+					# Reject a line xargs cannot parse (e.g. unbalanced quotes) instead of
+					# running 'oc wait' with a silently truncated argv.
+					if ! printf '%s\n' "$_cond" | xargs >/dev/null 2>&1; then
+						aba_warning "Wave $entry_name: cannot parse .wait line (unbalanced quotes?), skipping: $_cond"
+						continue
+					fi
 					aba_info "Wave $entry_name: waiting for 'oc wait $_cond' ..."
 					aba_debug "Running: oc wait $_cond"
 					# Parse the line with xargs so shell-style quoting in copy-pasted

--- a/scripts/day2.sh
+++ b/scripts/day2.sh
@@ -234,11 +234,18 @@ apply_custom_manifests() {
 		# each numbered wave in order, gating on an optional per-wave '.wait' file.
 		aba_info "Applying user-provided custom manifests in waves ..."
 
-		local flat_files
-		flat_files="$(find "$custom_manifest_dir" -mindepth 1 -maxdepth 1 -type f \( -name '*.yaml' -o -name '*.yml' \) | sort)"
-		if [ -n "$flat_files" ]; then
-			aba_info "Applying top-level manifests before the first wave ..."
-			_apply_manifest_list "$flat_files"
+		# Default group = every manifest NOT inside a numbered wave dir. This keeps
+		# the legacy recursive coverage (flat files AND non-numbered subdirs still
+		# apply), so enabling waves never silently drops other manifests.
+		local default_files wd
+		default_files="$(find "$custom_manifest_dir" -type f \( -name '*.yaml' -o -name '*.yml' \) | sort)"
+		while IFS= read -r wd; do
+			[ -z "$wd" ] && continue
+			default_files="$(printf '%s\n' "$default_files" | grep -vF "$wd/" || true)"
+		done <<< "$wave_dirs"
+		if [ -n "$default_files" ]; then
+			aba_info "Applying non-wave manifests before the first wave ..."
+			_apply_manifest_list "$default_files"
 		fi
 
 		local wave wave_name wave_files _cond
@@ -254,6 +261,8 @@ apply_custom_manifests() {
 			if [ -f "$wave/.wait" ]; then
 				while IFS= read -r _cond || [ -n "$_cond" ]; do
 					_cond="${_cond%$'\r'}"
+					_cond="${_cond#"${_cond%%[![:space:]]*}"}"   # trim leading whitespace
+					_cond="${_cond%"${_cond##*[![:space:]]}"}"   # trim trailing whitespace
 					[ -z "$_cond" ] && continue
 					case "$_cond" in \#*) continue ;; esac
 					aba_info "Wave $wave_name: waiting for 'oc wait $_cond' ..."

--- a/scripts/day2.sh
+++ b/scripts/day2.sh
@@ -230,49 +230,47 @@ apply_custom_manifests() {
 		aba_info "Applying user-provided custom manifests ..."
 		_apply_manifest_list "$found_files"
 	else
-		# WAVED layout: apply top-level flat files first (backward compatible), then
-		# each numbered wave in order, gating on an optional per-wave '.wait' file.
+		# WAVED layout: numbered wave dirs are present. Apply every top-level entry
+		# (files and dirs) in NUMERIC order (sort -V, so 2- before 10-), which keeps
+		# the legacy relative ordering of non-wave files (e.g. 99-post applies after a
+		# 10-operators wave). A numbered dir is a "wave": after applying it, an optional
+		# per-wave '.wait' file gates the next entry via 'oc wait'. Non-numbered files
+		# and dirs apply at their sorted position, so nothing is dropped.
 		aba_info "Applying user-provided custom manifests in waves ..."
 
-		# Default group = every manifest NOT inside a numbered wave dir. This keeps
-		# the legacy recursive coverage (flat files AND non-numbered subdirs still
-		# apply), so enabling waves never silently drops other manifests.
-		local default_files wd
-		default_files="$(find "$custom_manifest_dir" -type f \( -name '*.yaml' -o -name '*.yml' \) | sort)"
-		while IFS= read -r wd; do
-			[ -z "$wd" ] && continue
-			default_files="$(printf '%s\n' "$default_files" | grep -vF "$wd/" || true)"
-		done <<< "$wave_dirs"
-		if [ -n "$default_files" ]; then
-			aba_info "Applying non-wave manifests before the first wave ..."
-			_apply_manifest_list "$default_files"
-		fi
+		local entry entry_name entry_files _cond
+		while IFS= read -r entry; do
+			[ -z "$entry" ] && continue
+			entry_name="$(basename "$entry")"
+			if [ -d "$entry" ]; then
+				entry_files="$(find "$entry" -type f \( -name '*.yaml' -o -name '*.yml' \) | sort)"
+			elif [ -f "$entry" ]; then
+				case "$entry" in *.yaml|*.yml) entry_files="$entry" ;; *) continue ;; esac
+			else
+				continue
+			fi
+			if [ -n "$entry_files" ]; then
+				aba_info "Applying: $entry_name"
+				_apply_manifest_list "$entry_files"
+			fi
 
-		local wave wave_name wave_files _cond
-		while IFS= read -r wave; do
-			[ -z "$wave" ] && continue
-			wave_name="$(basename "$wave")"
-			wave_files="$(find "$wave" -type f \( -name '*.yaml' -o -name '*.yml' \) | sort)"
-			aba_info "Applying day2 wave: $wave_name"
-			_apply_manifest_list "$wave_files"
-
-			# Optional gate: one 'oc wait' condition per non-comment line in .wait.
-			# A failed/timed-out wait is non-fatal so day2 can continue.
-			if [ -f "$wave/.wait" ]; then
+			# Optional gate on a wave dir: one 'oc wait' condition per non-comment line
+			# in '.wait'. A failed/timed-out wait is non-fatal so day2 can continue.
+			if [ -d "$entry" ] && [ -f "$entry/.wait" ]; then
 				while IFS= read -r _cond || [ -n "$_cond" ]; do
 					_cond="${_cond%$'\r'}"
 					_cond="${_cond#"${_cond%%[![:space:]]*}"}"   # trim leading whitespace
 					_cond="${_cond%"${_cond##*[![:space:]]}"}"   # trim trailing whitespace
 					[ -z "$_cond" ] && continue
 					case "$_cond" in \#*) continue ;; esac
-					aba_info "Wave $wave_name: waiting for 'oc wait $_cond' ..."
+					aba_info "Wave $entry_name: waiting for 'oc wait $_cond' ..."
 					aba_debug "Running: oc wait $_cond"
 					if ! oc wait $_cond; then
-						aba_warning "Wave $wave_name: 'oc wait $_cond' failed or timed out (continuing)"
+						aba_warning "Wave $entry_name: 'oc wait $_cond' failed or timed out (continuing)"
 					fi
-				done < "$wave/.wait"
+				done < "$entry/.wait"
 			fi
-		done <<< "$wave_dirs"
+		done <<< "$(find "$custom_manifest_dir" -mindepth 1 -maxdepth 1 | sort -V)"
 	fi
 
 	# Show summary

--- a/scripts/day2.sh
+++ b/scripts/day2.sh
@@ -265,7 +265,13 @@ apply_custom_manifests() {
 					_cond="${_cond%$'\r'}"
 					_cond="${_cond#"${_cond%%[![:space:]]*}"}"   # trim leading whitespace
 					case "$_cond" in \#*) continue ;; esac         # skip full-line comments first
-					_cond="${_cond%% #*}"                          # strip an unquoted trailing ' # comment'
+					# Strip a trailing ' # comment', but ONLY if doing so keeps the line
+					# xargs-parseable; otherwise the '#' is inside a quoted value (e.g. a
+					# selector like --selector='app=web #1') and must be preserved.
+					_stripped="${_cond%% #*}"
+					if [ "$_stripped" != "$_cond" ] && printf '%s\n' "$_stripped" | xargs >/dev/null 2>&1; then
+						_cond="$_stripped"
+					fi
 					_cond="${_cond%"${_cond##*[![:space:]]}"}"   # trim trailing whitespace
 					[ -z "$_cond" ] && continue
 					# Reject a line xargs cannot parse (e.g. unbalanced quotes) instead of

--- a/scripts/day2.sh
+++ b/scripts/day2.sh
@@ -265,7 +265,9 @@ apply_custom_manifests() {
 					case "$_cond" in \#*) continue ;; esac
 					aba_info "Wave $entry_name: waiting for 'oc wait $_cond' ..."
 					aba_debug "Running: oc wait $_cond"
-					if ! oc wait $_cond; then
+					# Parse the line with xargs so shell-style quoting in copy-pasted
+					# 'oc wait --for=jsonpath='\''{...}'\'' ...' examples is honored.
+					if ! printf '%s\n' "$_cond" | xargs -r oc wait; then
 						aba_warning "Wave $entry_name: 'oc wait $_cond' failed or timed out (continuing)"
 					fi
 				done < "$entry/.wait"

--- a/scripts/day2.sh
+++ b/scripts/day2.sh
@@ -178,51 +178,93 @@ apply_custom_manifests() {
 		return 0
 	fi
 
-	# Recursively discover .yaml/.yml files; sort ensures deterministic alphabetical
-	# order so users can control ordering via directory/file naming (e.g. 00-ns/, 01-app/)
-	local found_files
-	found_files="$(find "$custom_manifest_dir" -type f \( -name '*.yaml' -o -name '*.yml' \) | sort)"
-
-	# Count matched files; grep -c exits 1 on zero matches, so suppress that with || true
-	local file_count
-	file_count="$(printf '%s\n' "$found_files" | grep -c . || true)"
-
-	# If no files found, inform user and return
-	if [ "$file_count" -eq 0 ]; then
-		aba_debug "No custom manifest files (.yaml/.yml) found in $custom_manifest_dir"
-		return 0
-	fi
-
-	# Show what we're doing
-	aba_info "Found $file_count custom manifest file(s) in $custom_manifest_dir"
-	aba_info "Applying user-provided custom manifests ..."
-
-	# Track successes and failures
+	# Track successes and failures across every apply (flat and waved).
 	local success_count=0
 	local failure_count=0
 
-	# Apply each file; while+read handles filenames that contain spaces
-	while IFS= read -r manifest_file; do
-		# Show path relative to the custom manifests directory for cleaner output
-		local rel_path="${manifest_file#"$custom_manifest_dir"/}"  # strip base dir → relative path
+	# Apply a newline-separated, pre-sorted list of manifest files. while+read
+	# handles filenames containing spaces. Failures are non-fatal (logged, counted).
+	_apply_manifest_list() {
+		local _files="$1" manifest_file rel_path
+		[ -z "$_files" ] && return 0
+		while IFS= read -r manifest_file; do
+			[ -z "$manifest_file" ] && continue
+			# Show path relative to the custom manifests dir for cleaner output
+			rel_path="${manifest_file#"$custom_manifest_dir"/}"
 
-		# Verify file is not empty
-		if [ ! -s "$manifest_file" ]; then
-			aba_warning "Skipping empty file: $rel_path"
-			failure_count=$((failure_count + 1))
-			continue
+			# Verify file is not empty
+			if [ ! -s "$manifest_file" ]; then
+				aba_warning "Skipping empty file: $rel_path"
+				failure_count=$((failure_count + 1))
+				continue
+			fi
+
+			# Apply the manifest
+			aba_info "oc apply -f $rel_path"
+			aba_debug "Running: oc apply -f $manifest_file"
+			if oc apply -f "$manifest_file"; then
+				success_count=$((success_count + 1))
+			else
+				aba_warning "Failed to apply custom manifest: $rel_path (continuing with other files)"
+				failure_count=$((failure_count + 1))
+			fi
+		done <<< "$_files"
+	}
+
+	# Discover numbered "wave" subdirs (names starting with a digit), sorted
+	# NUMERICALLY (sort -V, so 2-foo comes before 10-foo, not lexicographically).
+	local wave_dirs
+	wave_dirs="$(find "$custom_manifest_dir" -mindepth 1 -maxdepth 1 -type d -name '[0-9]*' | sort -V)"
+
+	if [ -z "$wave_dirs" ]; then
+		# FLAT / legacy layout: no numbered wave dirs. Apply every .yaml/.yml
+		# recursively in sorted order so users can order via file naming (00-, 01-).
+		local found_files file_count
+		found_files="$(find "$custom_manifest_dir" -type f \( -name '*.yaml' -o -name '*.yml' \) | sort)"
+		file_count="$(printf '%s\n' "$found_files" | grep -c . || true)"
+		if [ "$file_count" -eq 0 ]; then
+			aba_debug "No custom manifest files (.yaml/.yml) found in $custom_manifest_dir"
+			return 0
+		fi
+		aba_info "Found $file_count custom manifest file(s) in $custom_manifest_dir"
+		aba_info "Applying user-provided custom manifests ..."
+		_apply_manifest_list "$found_files"
+	else
+		# WAVED layout: apply top-level flat files first (backward compatible), then
+		# each numbered wave in order, gating on an optional per-wave '.wait' file.
+		aba_info "Applying user-provided custom manifests in waves ..."
+
+		local flat_files
+		flat_files="$(find "$custom_manifest_dir" -mindepth 1 -maxdepth 1 -type f \( -name '*.yaml' -o -name '*.yml' \) | sort)"
+		if [ -n "$flat_files" ]; then
+			aba_info "Applying top-level manifests before the first wave ..."
+			_apply_manifest_list "$flat_files"
 		fi
 
-		# Apply the manifest
-		aba_info "oc apply -f $rel_path"
-		aba_debug "Running: oc apply -f $manifest_file"
-		if oc apply -f "$manifest_file"; then
-			success_count=$((success_count + 1))
-		else
-			aba_warning "Failed to apply custom manifest: $rel_path (continuing with other files)"
-			failure_count=$((failure_count + 1))
-		fi
-	done <<< "$found_files"
+		local wave wave_name wave_files _cond
+		while IFS= read -r wave; do
+			[ -z "$wave" ] && continue
+			wave_name="$(basename "$wave")"
+			wave_files="$(find "$wave" -type f \( -name '*.yaml' -o -name '*.yml' \) | sort)"
+			aba_info "Applying day2 wave: $wave_name"
+			_apply_manifest_list "$wave_files"
+
+			# Optional gate: one 'oc wait' condition per non-comment line in .wait.
+			# A failed/timed-out wait is non-fatal so day2 can continue.
+			if [ -f "$wave/.wait" ]; then
+				while IFS= read -r _cond || [ -n "$_cond" ]; do
+					_cond="${_cond%$'\r'}"
+					[ -z "$_cond" ] && continue
+					case "$_cond" in \#*) continue ;; esac
+					aba_info "Wave $wave_name: waiting for 'oc wait $_cond' ..."
+					aba_debug "Running: oc wait $_cond"
+					if ! oc wait $_cond; then
+						aba_warning "Wave $wave_name: 'oc wait $_cond' failed or timed out (continuing)"
+					fi
+				done < "$wave/.wait"
+			fi
+		done <<< "$wave_dirs"
+	fi
 
 	# Show summary
 	if [ $success_count -gt 0 ]; then

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -38,18 +38,23 @@ export INFO_ABA=1
 deploy_run() {
 	local aba_home="$1" site_dir="$2" cluster="$3" platform="$4"
 
-	# Run (or, in dry-run, preview) one pipeline step. run_once -S makes the step
-	# run exactly once across invocations, so a re-run skips completed steps.
+	# Scope run_once state per aba tree (and, once known, per cluster) so deploy state
+	# never collides across trees/clusters that share $HOME/.aba/runner. A fresh
+	# re-deploy after a teardown clears the cached state with 'aba deploy --restart'.
+	local _scope; _scope="$(printf '%s' "$aba_home" | cksum | cut -d' ' -f1)"
+
+	# Run (or, in dry-run, preview) one pipeline step. run_once -S runs the step once
+	# across invocations, so a re-run skips a COMPLETED step (resume).
 	_step() {
 		local id="$1" msg="$2"; shift 2
 		if [ -n "$ABA_DEPLOY_DRY_RUN" ]; then
 			aba_info "DRY RUN [$id]: $*"
 			return 0
 		fi
-		local task="aba:deploy:$id"
-		# Resume semantics: run_once -S skips a COMPLETED step, but it also caches a
-		# FAILED step and would keep returning that cached failure. Reset a previously
-		# failed step so a re-run retries it, while completed steps stay skipped.
+		local task="aba:deploy:$_scope:$id"
+		[ -n "$DEPLOY_RESTART" ] && run_once -r -i "$task" >/dev/null 2>&1   # --restart: force re-run
+		# run_once -S caches a FAILED step too and would keep returning that cached
+		# failure; reset a previously failed step so a re-run retries it.
 		local prev_exit
 		prev_exit="$(run_once -E -i "$task" 2>/dev/null)"
 		[ -n "$prev_exit" ] && [ "$prev_exit" != "0" ] && run_once -r -i "$task" >/dev/null 2>&1
@@ -63,16 +68,29 @@ deploy_run() {
 	aba_info "Deploying from site '$site_dir' ..."
 
 	# Config import FIRST so nothing re-templates over the imported files, and so the
-	# cluster dir + aba.conf exist before we resolve the cluster and platform.
-	_step config-import "Importing site configuration" "$aba_home/scripts/config-import.sh" import "$site_dir"
+	# cluster dir + aba.conf exist before we resolve the cluster and platform. Skip it
+	# when there is no site payload (an already-configured tree deploys in place).
+	if [ -d "$aba_home/$site_dir" ] || [ -d "$site_dir" ]; then
+		_step config-import "Importing site configuration" "$aba_home/scripts/config-import.sh" import "$site_dir"
+	else
+		aba_info "No site payload at '$site_dir' - using the configs already in place."
+	fi
 
 	# Resolve cluster + platform from the imported/available configs (read-only, so
 	# this is also correct in dry-run). Detecting AFTER import means a bring-your-own
 	# -configs deploy works with just a site payload, and hypervisor clusters take the
-	# 'make install' path instead of the bare-metal pause.
-	[ -n "$cluster" ]  || cluster="$(_detect_cluster "$aba_home" "$site_dir")"
+	# 'make install' path instead of the bare-metal pause. The multi-cluster abort runs
+	# here (not inside _detect_cluster's $() subshell) so it actually exits deploy.
+	if [ -z "$cluster" ]; then
+		local _found _n
+		_found="$(_detect_cluster "$aba_home" "$site_dir")"
+		_n="$(printf '%s' "$_found" | grep -c . || true)"
+		[ "$_n" -gt 1 ] && aba_abort "aba deploy: multiple clusters found ($(printf '%s' "$_found" | tr '\n' ' ')); pick one with --cluster <name> or cluster_name in deploy.conf."
+		cluster="$(printf '%s' "$_found" | head -1)"
+	fi
 	[ -n "$platform" ] || platform="$(cd "$aba_home" && _detect_platform)"
 	[ -n "$cluster" ] || aba_abort "aba deploy: no cluster specified and none found (set cluster_name in deploy.conf or use --cluster <name>)."
+	_scope="$_scope:$cluster"   # scope subsequent steps per cluster too
 	aba_info "Cluster '$cluster' (platform ${platform:-unknown})"
 
 	_step mirror-install "Installing/connecting the mirror registry"  make -C "$aba_home/mirror" install
@@ -113,26 +131,25 @@ deploy_run() {
 	return 0
 }
 
-# _detect_cluster <aba_home> <site_dir>: echo the single cluster dir name (a
-# subdir with cluster.conf), or "" if none / abort if more than one. Looks in the
-# aba tree first, then falls back to the site payload (config-import materializes
-# it into the tree).
+# _detect_cluster <aba_home> <site_dir>: echo the cluster dir name(s) (subdirs with
+# cluster.conf), one per line, from the first base that has any. Looks in the aba
+# tree first, then falls back to the site payload (config-import materializes it into
+# the tree). It never aborts - the caller decides what 0 or >1 results mean, so its
+# exit status is not swallowed by a $() command substitution.
 _detect_cluster() {
-	local home="$1" site="$2" base d name found=""
+	local home="$1" site="$2" base d name out
 	for base in "$home" "$home/$site" "$site"; do
 		[ -d "$base" ] || continue
+		out=""
 		for d in "$base"/*/; do
 			[ -d "$d" ] || continue
 			[ -f "$d/cluster.conf" ] || continue
 			name="$(basename "$d")"
 			case "$name" in mirror|site|helm) continue ;; esac
-			[ "$found" = "$name" ] && continue
-			[ -z "$found" ] || aba_abort "aba deploy: multiple clusters found; pick one with --cluster <name> or cluster_name in deploy.conf."
-			found="$name"
+			out="$out$name"$'\n'
 		done
-		[ -n "$found" ] && break
+		[ -n "$out" ] && { printf '%s' "$out"; return 0; }
 	done
-	echo "$found"
 }
 
 # _detect_platform: echo the platform (vmw/kvm/bm) from aba.conf, or "".
@@ -157,6 +174,7 @@ while [ "$1" ]; do
 		--site)    [ -n "$2" ] || aba_abort "aba deploy: --site requires a value"; _site="$2"; shift 2 ;;
 		--cluster) [ -n "$2" ] || aba_abort "aba deploy: --cluster requires a value"; _cluster="$2"; shift 2 ;;
 		--dry-run) export ABA_DEPLOY_DRY_RUN=1; shift ;;
+		--restart) export DEPLOY_RESTART=1; shift ;;   # clear cached step state (fresh re-deploy)
 		import)    shift ;;   # tolerate a stray leading verb
 		--*)       aba_abort "aba deploy: unknown option '$1' (see 'aba deploy --help')." ;;
 		*)         shift ;;

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -38,8 +38,6 @@ export INFO_ABA=1
 deploy_run() {
 	local aba_home="$1" site_dir="$2" cluster="$3" platform="$4"
 
-	[ -n "$cluster" ] || aba_abort "aba deploy: no cluster specified (set cluster_name in deploy.conf or use --cluster <name>)."
-
 	# Run (or, in dry-run, preview) one pipeline step. run_once -S makes the step
 	# run exactly once across invocations, so a re-run skips completed steps.
 	_step() {
@@ -62,13 +60,24 @@ deploy_run() {
 		return 0
 	}
 
-	aba_info "Deploying: site='$site_dir' cluster='$cluster' platform='${platform:-unknown}'"
+	aba_info "Deploying from site '$site_dir' ..."
 
-	# 1-4: configs first (so nothing re-templates over them), then mirror, then ISO.
-	_step config-import  "Importing site configuration"                  "$aba_home/scripts/config-import.sh" import "$site_dir"
-	_step mirror-install "Installing/connecting the mirror registry"     make -C "$aba_home/mirror" install
-	_step mirror-load    "Loading images into the mirror registry"       make -C "$aba_home/mirror" load
-	_step iso            "Generating the agent-based ISO"                make -C "$aba_home/$cluster" iso
+	# Config import FIRST so nothing re-templates over the imported files, and so the
+	# cluster dir + aba.conf exist before we resolve the cluster and platform.
+	_step config-import "Importing site configuration" "$aba_home/scripts/config-import.sh" import "$site_dir"
+
+	# Resolve cluster + platform from the imported/available configs (read-only, so
+	# this is also correct in dry-run). Detecting AFTER import means a bring-your-own
+	# -configs deploy works with just a site payload, and hypervisor clusters take the
+	# 'make install' path instead of the bare-metal pause.
+	[ -n "$cluster" ]  || cluster="$(_detect_cluster "$aba_home" "$site_dir")"
+	[ -n "$platform" ] || platform="$(cd "$aba_home" && _detect_platform)"
+	[ -n "$cluster" ] || aba_abort "aba deploy: no cluster specified and none found (set cluster_name in deploy.conf or use --cluster <name>)."
+	aba_info "Cluster '$cluster' (platform ${platform:-unknown})"
+
+	_step mirror-install "Installing/connecting the mirror registry"  make -C "$aba_home/mirror" install
+	_step mirror-load    "Loading images into the mirror registry"    make -C "$aba_home/mirror" load
+	_step iso            "Generating the agent-based ISO"             make -C "$aba_home/$cluster" iso
 
 	# Node boot gate. Hypervisors boot automatically; anything else (bare metal or
 	# unknown) pauses once after the ISO so the operator can boot the node(s).
@@ -81,7 +90,9 @@ deploy_run() {
 			aba_info_ok "ISO ready. Boot your node(s) from the ISO, then re-run 'aba deploy' to continue."
 			return 0
 		else
-			rm -f "$_await"
+			# Marker present: boot was already prompted. Latch (keep the marker) and
+			# continue, so any re-run proceeds to the run_once-guarded monitor/day2
+			# steps rather than pausing again.
 			aba_info "Resuming after node boot; continuing to installation monitoring ..."
 		fi
 	fi
@@ -102,17 +113,24 @@ deploy_run() {
 	return 0
 }
 
-# _detect_cluster <aba_home>: echo the single cluster dir (a subdir with
-# cluster.conf), or "" if none / abort if more than one.
+# _detect_cluster <aba_home> <site_dir>: echo the single cluster dir name (a
+# subdir with cluster.conf), or "" if none / abort if more than one. Looks in the
+# aba tree first, then falls back to the site payload (config-import materializes
+# it into the tree).
 _detect_cluster() {
-	local home="$1" d name found=""
-	for d in "$home"/*/; do
-		[ -d "$d" ] || continue
-		[ -f "$d/cluster.conf" ] || continue
-		name="$(basename "$d")"
-		case "$name" in mirror|site|helm) continue ;; esac
-		[ -z "$found" ] || aba_abort "aba deploy: multiple clusters found; pick one with --cluster <name> or cluster_name in deploy.conf."
-		found="$name"
+	local home="$1" site="$2" base d name found=""
+	for base in "$home" "$home/$site" "$site"; do
+		[ -d "$base" ] || continue
+		for d in "$base"/*/; do
+			[ -d "$d" ] || continue
+			[ -f "$d/cluster.conf" ] || continue
+			name="$(basename "$d")"
+			case "$name" in mirror|site|helm) continue ;; esac
+			[ "$found" = "$name" ] && continue
+			[ -z "$found" ] || aba_abort "aba deploy: multiple clusters found; pick one with --cluster <name> or cluster_name in deploy.conf."
+			found="$name"
+		done
+		[ -n "$found" ] && break
 	done
 	echo "$found"
 }
@@ -136,15 +154,15 @@ _cluster="${cluster_name:-}"
 
 while [ "$1" ]; do
 	case "$1" in
-		--site)    _site="$2"; shift 2 ;;
-		--cluster) _cluster="$2"; shift 2 ;;
+		--site)    [ -n "$2" ] || aba_abort "aba deploy: --site requires a value"; _site="$2"; shift 2 ;;
+		--cluster) [ -n "$2" ] || aba_abort "aba deploy: --cluster requires a value"; _cluster="$2"; shift 2 ;;
 		--dry-run) export ABA_DEPLOY_DRY_RUN=1; shift ;;
-		import)    shift ;;   # tolerate a stray verb
+		import)    shift ;;   # tolerate a stray leading verb
+		--*)       aba_abort "aba deploy: unknown option '$1' (see 'aba deploy --help')." ;;
 		*)         shift ;;
 	esac
 done
 
-[ -n "$_cluster" ] || _cluster="$(_detect_cluster "$aba_home")"
-_platform="$(_detect_platform)"
-
-deploy_run "$aba_home" "$_site" "$_cluster" "$_platform"
+# cluster + platform are resolved inside deploy_run, after config-import has
+# materialized the cluster dir and aba.conf.
+deploy_run "$aba_home" "$_site" "$_cluster" ""

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -19,10 +19,12 @@
 # DESCRIPTOR: an optional deploy.conf (sourced key=value, like aba.conf) may set
 #           site_dir (configs to import; default 'site') and cluster_name.
 #
-# USAGE:    aba deploy [--site <dir>] [--cluster <name>] [--dry-run]
+# USAGE:    aba deploy [--site <dir>] [--cluster <name>] [--dry-run] [--restart]
 #
 # PREVIEW:  ABA_DEPLOY_DRY_RUN=1 aba deploy   (or --dry-run) prints the plan only.
+# RESTART:  aba deploy --restart clears cached step state for a fresh re-deploy.
 
+_CALLER_PWD="$PWD"   # user's cwd, captured before we cd to the aba root (to resolve a relative --site)
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 cd "$SCRIPT_DIR/.." || exit 1
 source scripts/include_all.sh
@@ -36,7 +38,7 @@ export INFO_ABA=1
 # (passed explicitly so this stays independent of aba.sh globals). Honors
 # ABA_DEPLOY_DRY_RUN to print the plan without executing anything.
 deploy_run() {
-	local aba_home="$1" site_dir="$2" cluster="$3" platform="$4"
+	local aba_home="$1" site_dir="$2" cluster="$3" platform="$4" site_explicit="$5"
 
 	# Scope run_once state per aba tree (and, once known, per cluster) so deploy state
 	# never collides across trees/clusters that share $HOME/.aba/runner. A fresh
@@ -52,7 +54,8 @@ deploy_run() {
 			return 0
 		fi
 		local task="aba:deploy:$_scope:$id"
-		[ -n "$DEPLOY_RESTART" ] && run_once -r -i "$task" >/dev/null 2>&1   # --restart: force re-run
+		# --restart is handled EAGERLY (all step ids reset up front, below) rather than
+		# here, so an interrupted restart cannot leave later steps cached as succeeded.
 		# run_once -S caches a FAILED step too and would keep returning that cached
 		# failure; reset a previously failed step so a re-run retries it.
 		local prev_exit
@@ -72,13 +75,26 @@ deploy_run() {
 	# when there is no site payload (an already-configured tree deploys in place).
 	# config-import is idempotent (verbatim copy), so it always runs - never cached by
 	# run_once, whose per-tree id could otherwise skip importing a different --site.
-	if [ -n "$ABA_DEPLOY_DRY_RUN" ]; then
-		aba_info "DRY RUN [config-import]: $aba_home/scripts/config-import.sh import $site_dir"
-	elif [ -d "$aba_home/$site_dir" ] || [ -d "$site_dir" ]; then
-		aba_info "==> Importing site configuration"
-		"$aba_home/scripts/config-import.sh" import "$site_dir" || aba_abort "aba deploy: step 'config-import' failed. Fix the problem and re-run 'aba deploy'."
+
+	# A missing EXPLICIT --site (or a deploy.conf site_dir) is a user error: abort in
+	# both real and dry-run mode instead of silently deploying whatever is in the tree.
+	if [ -n "$site_explicit" ] && [ ! -d "$aba_home/$site_dir" ] && [ ! -d "$site_dir" ]; then
+		aba_abort "aba deploy: site directory '$site_dir' not found (from --site or deploy.conf)."
+	fi
+
+	if [ -d "$aba_home/$site_dir" ] || [ -d "$site_dir" ]; then
+		if [ -n "$ABA_DEPLOY_DRY_RUN" ]; then
+			aba_info "DRY RUN [config-import]: $aba_home/scripts/config-import.sh import $site_dir"
+		else
+			aba_info "==> Importing site configuration"
+			"$aba_home/scripts/config-import.sh" import "$site_dir" || aba_abort "aba deploy: step 'config-import' failed. Fix the problem and re-run 'aba deploy'."
+		fi
 	else
-		aba_info "No site payload at '$site_dir' - using the configs already in place."
+		if [ -n "$ABA_DEPLOY_DRY_RUN" ]; then
+			aba_info "DRY RUN: no site payload at '$site_dir' - would deploy the configs already in place"
+		else
+			aba_info "No site payload at '$site_dir' - using the configs already in place."
+		fi
 	fi
 
 	# Resolve cluster + platform from the imported/available configs (read-only, so
@@ -93,10 +109,26 @@ deploy_run() {
 		[ "$_n" -gt 1 ] && aba_abort "aba deploy: multiple clusters found ($(printf '%s' "$_found" | tr '\n' ' ')); pick one with --cluster <name> or cluster_name in deploy.conf."
 		cluster="$(printf '%s' "$_found" | head -1)"
 	fi
-	[ -n "$platform" ] || platform="$(cd "$aba_home" && _detect_platform)"
+	[ -n "$platform" ] || platform="$(_detect_platform "$aba_home" "$site_dir")"
 	[ -n "$cluster" ] || aba_abort "aba deploy: no cluster specified and none found (set cluster_name in deploy.conf or use --cluster <name>)."
 	_scope="$_scope:$cluster"   # scope subsequent steps per cluster too
 	aba_info "Cluster '$cluster' (platform ${platform:-unknown})"
+
+	# Boot marker path (bare-metal pause latch), needed both by --restart below and the boot gate.
+	local _await="$aba_home/$cluster/.aba-deploy-await-boot"
+
+	# --restart: fresh re-deploy. Clear ALL of this deploy's cached step state up front
+	# (not lazily as each step is reached), so an interrupted restart - a failed step or
+	# the bare-metal boot pause returning early - can never leave a later step cached as
+	# succeeded from a previous deployment. Also drop the boot marker so bare metal pauses
+	# exactly once per fresh deploy instead of latching straight through to monitoring.
+	if [ -n "$DEPLOY_RESTART" ] && [ -z "$ABA_DEPLOY_DRY_RUN" ]; then
+		local _s
+		for _s in mirror-install mirror-load iso install monitor day2; do
+			run_once -r -i "aba:deploy:$_scope:$_s" >/dev/null 2>&1
+		done
+		rm -f "$_await"
+	fi
 
 	_step mirror-install "Installing/connecting the mirror registry"  make -C "$aba_home/mirror" install
 	_step mirror-load    "Loading images into the mirror registry"    make -C "$aba_home/mirror" load
@@ -105,7 +137,6 @@ deploy_run() {
 	# Node boot gate. Hypervisors boot automatically; anything else (bare metal or
 	# unknown) pauses once after the ISO so the operator can boot the node(s).
 	if [ "$platform" != "vmw" ] && [ "$platform" != "kvm" ]; then
-		local _await="$aba_home/$cluster/.aba-deploy-await-boot"
 		if [ -n "$ABA_DEPLOY_DRY_RUN" ]; then
 			aba_info "DRY RUN [boot]: pause for manual node boot here, then re-run 'aba deploy' to resume"
 		elif [ ! -f "$_await" ]; then
@@ -157,9 +188,17 @@ _detect_cluster() {
 	done
 }
 
-# _detect_platform: echo the platform (vmw/kvm/bm) from aba.conf, or "".
+# _detect_platform <aba_home> <site_dir>: echo the platform (vmw/kvm or empty) from the
+# first aba.conf found - the aba tree first, then the site payload. The site fallback
+# matches _detect_cluster so a dry-run on a fresh tree + site payload (config-import not
+# yet run) still previews the right pipeline (straight-through vs bare-metal pause).
 _detect_platform() {
-	( source <(normalize-aba-conf) 2>/dev/null; echo "$platform" )
+	local home="$1" site="$2" base
+	for base in "$home" "$home/$site" "$site"; do
+		[ -f "$base/aba.conf" ] || continue
+		( cd "$base" && source <(normalize-aba-conf) 2>/dev/null; echo "$platform" )
+		return 0
+	done
 }
 
 # ---- run (the unit test extracts deploy_run and never reaches here) ----------
@@ -173,19 +212,30 @@ cluster_name=""
 # Descriptor values (if set) become the defaults; CLI flags override below.
 _site="${site_dir:-site}"
 _cluster="${cluster_name:-}"
+# A non-default site_dir from deploy.conf counts as explicit (a missing one must abort,
+# not silently deploy in place); a plain default './site' stays implicit.
+_site_explicit=""
+[ "$_site" != "site" ] && _site_explicit=1
 
 while [ "$1" ]; do
 	case "$1" in
-		--site)    [ -n "$2" ] || aba_abort "aba deploy: --site requires a value"; _site="$2"; shift 2 ;;
-		--cluster) [ -n "$2" ] || aba_abort "aba deploy: --cluster requires a value"; _cluster="$2"; shift 2 ;;
-		--dry-run) export ABA_DEPLOY_DRY_RUN=1; shift ;;
-		--restart) export DEPLOY_RESTART=1; shift ;;   # clear cached step state (fresh re-deploy)
-		import)    shift ;;   # tolerate a stray leading verb
-		--*)       aba_abort "aba deploy: unknown option '$1' (see 'aba deploy --help')." ;;
-		*)         shift ;;
+		--site)       [ -n "$2" ] || aba_abort "aba deploy: --site requires a value"; _site="$2"; _site_explicit=1; shift 2 ;;
+		--cluster)    [ -n "$2" ] || aba_abort "aba deploy: --cluster requires a value"; _cluster="$2"; shift 2 ;;
+		-n|--name)    [ -n "$2" ] || aba_abort "aba deploy: $1 requires a value"; _cluster="$2"; shift 2 ;;   # accept aba's cluster-name syntax
+		--dry-run)    export ABA_DEPLOY_DRY_RUN=1; shift ;;
+		--restart)    export DEPLOY_RESTART=1; shift ;;   # clear cached step state (fresh re-deploy)
+		import)       shift ;;   # tolerate a stray leading verb
+		-*)           aba_abort "aba deploy: unknown option '$1' (see 'aba deploy --help')." ;;
+		*)            aba_abort "aba deploy: unexpected argument '$1' (see 'aba deploy --help')." ;;
 	esac
 done
 
+# Resolve an explicit relative --site against the user's original cwd (not the aba root
+# this script cd'd to); the implicit default './site' stays relative to the aba root.
+if [ -n "$_site_explicit" ]; then
+	case "$_site" in /*) ;; *) _site="$_CALLER_PWD/$_site" ;; esac
+fi
+
 # cluster + platform are resolved inside deploy_run, after config-import has
 # materialized the cluster dir and aba.conf.
-deploy_run "$aba_home" "$_site" "$_cluster" ""
+deploy_run "$aba_home" "$_site" "$_cluster" "" "$_site_explicit"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -70,8 +70,13 @@ deploy_run() {
 	# Config import FIRST so nothing re-templates over the imported files, and so the
 	# cluster dir + aba.conf exist before we resolve the cluster and platform. Skip it
 	# when there is no site payload (an already-configured tree deploys in place).
-	if [ -d "$aba_home/$site_dir" ] || [ -d "$site_dir" ]; then
-		_step config-import "Importing site configuration" "$aba_home/scripts/config-import.sh" import "$site_dir"
+	# config-import is idempotent (verbatim copy), so it always runs - never cached by
+	# run_once, whose per-tree id could otherwise skip importing a different --site.
+	if [ -n "$ABA_DEPLOY_DRY_RUN" ]; then
+		aba_info "DRY RUN [config-import]: $aba_home/scripts/config-import.sh import $site_dir"
+	elif [ -d "$aba_home/$site_dir" ] || [ -d "$site_dir" ]; then
+		aba_info "==> Importing site configuration"
+		"$aba_home/scripts/config-import.sh" import "$site_dir" || aba_abort "aba deploy: step 'config-import' failed. Fix the problem and re-run 'aba deploy'."
 	else
 		aba_info "No site payload at '$site_dir' - using the configs already in place."
 	fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -193,11 +193,13 @@ _detect_cluster() {
 # matches _detect_cluster so a dry-run on a fresh tree + site payload (config-import not
 # yet run) still previews the right pipeline (straight-through vs bare-metal pause).
 _detect_platform() {
-	local home="$1" site="$2" base
+	local home="$1" site="$2" base _p
 	for base in "$home" "$home/$site" "$site"; do
 		[ -f "$base/aba.conf" ] || continue
-		( cd "$base" && source <(normalize-aba-conf) 2>/dev/null; echo "$platform" )
-		return 0
+		# Fall through to a later base if this aba.conf sets no platform (empty), so a
+		# tree aba.conf without platform= does not mask a site payload that sets it.
+		_p="$( cd "$base" && source <(normalize-aba-conf) 2>/dev/null; echo "$platform" )"
+		[ -n "$_p" ] && { printf '%s' "$_p"; return 0; }
 	done
 }
 
@@ -212,27 +214,30 @@ cluster_name=""
 # Descriptor values (if set) become the defaults; CLI flags override below.
 _site="${site_dir:-site}"
 _cluster="${cluster_name:-}"
-# A non-default site_dir from deploy.conf counts as explicit (a missing one must abort,
-# not silently deploy in place); a plain default './site' stays implicit.
+# A non-default site_dir counts as explicit (a missing one must abort, not silently
+# deploy in place); a plain default './site' stays implicit. _site_cli tracks whether
+# the value came from the CLI (resolved against the caller's cwd) vs deploy.conf
+# (anchored to the aba root, like the file itself).
 _site_explicit=""
+_site_cli=""
 [ "$_site" != "site" ] && _site_explicit=1
 
 while [ "$1" ]; do
 	case "$1" in
-		--site)       [ -n "$2" ] || aba_abort "aba deploy: --site requires a value"; _site="$2"; _site_explicit=1; shift 2 ;;
+		--site)       [ -n "$2" ] || aba_abort "aba deploy: --site requires a value"; _site="$2"; _site_explicit=1; _site_cli=1; shift 2 ;;
 		--cluster)    [ -n "$2" ] || aba_abort "aba deploy: --cluster requires a value"; _cluster="$2"; shift 2 ;;
 		-n|--name)    [ -n "$2" ] || aba_abort "aba deploy: $1 requires a value"; _cluster="$2"; shift 2 ;;   # accept aba's cluster-name syntax
 		--dry-run)    export ABA_DEPLOY_DRY_RUN=1; shift ;;
 		--restart)    export DEPLOY_RESTART=1; shift ;;   # clear cached step state (fresh re-deploy)
 		import)       shift ;;   # tolerate a stray leading verb
 		-*)           aba_abort "aba deploy: unknown option '$1' (see 'aba deploy --help')." ;;
-		*)            aba_abort "aba deploy: unexpected argument '$1' (see 'aba deploy --help')." ;;
+		*)            [ -z "$_cluster" ] && { _cluster="$1"; shift; } || aba_abort "aba deploy: unexpected argument '$1' (see 'aba deploy --help')." ;;   # a lone positional is the cluster name
 	esac
 done
 
-# Resolve an explicit relative --site against the user's original cwd (not the aba root
-# this script cd'd to); the implicit default './site' stays relative to the aba root.
-if [ -n "$_site_explicit" ]; then
+# Resolve a relative --site given on the CLI against the user's original cwd (not the
+# aba root this script cd'd to). A deploy.conf site_dir stays anchored to the aba root.
+if [ -n "$_site_cli" ]; then
 	case "$_site" in /*) ;; *) _site="$_CALLER_PWD/$_site" ;; esac
 fi
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# deploy.sh -- One-command orchestrator for an air-gapped OpenShift install.
+#
+# INTENT:   Run the existing aba steps in the right order as an idempotent,
+#           resumable pipeline so a whole disconnected install is one command:
+#
+#             config import -> mirror install -> mirror load -> iso
+#                           -> (boot nodes) -> monitor -> day2
+#
+#           Each step is wrapped in run_once -S, so re-running 'aba deploy' skips
+#           already-completed steps and resumes where it left off. A failed step
+#           halts the pipeline; fix it and re-run to continue.
+#
+# NODE BOOT: aba cannot boot bare-metal nodes (BMC/PXE is out of scope). On bare
+#           metal deploy pauses after the ISO is built; boot the node(s) from the
+#           ISO, then re-run 'aba deploy' to resume at install monitoring.
+#           Hypervisors (vmw/kvm) boot their VMs automatically via 'make install'.
+#
+# DESCRIPTOR: an optional deploy.conf (sourced key=value, like aba.conf) may set
+#           site_dir (configs to import; default 'site') and cluster_name.
+#
+# USAGE:    aba deploy [--site <dir>] [--cluster <name>] [--dry-run]
+#
+# PREVIEW:  ABA_DEPLOY_DRY_RUN=1 aba deploy   (or --dry-run) prints the plan only.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+cd "$SCRIPT_DIR/.." || exit 1
+source scripts/include_all.sh
+
+# deploy is a user-facing orchestrator: make aba_info progress (and the dry-run
+# preview) visible even when this script is run directly (aba.sh sets this too).
+export INFO_ABA=1
+
+# deploy_run <aba_home> <site_dir> <cluster> <platform>
+# Orchestrate the ordered, resumable pipeline. aba_home is the aba root directory
+# (passed explicitly so this stays independent of aba.sh globals). Honors
+# ABA_DEPLOY_DRY_RUN to print the plan without executing anything.
+deploy_run() {
+	local aba_home="$1" site_dir="$2" cluster="$3" platform="$4"
+
+	[ -n "$cluster" ] || aba_abort "aba deploy: no cluster specified (set cluster_name in deploy.conf or use --cluster <name>)."
+
+	# Run (or, in dry-run, preview) one pipeline step. run_once -S makes the step
+	# run exactly once across invocations, so a re-run skips completed steps.
+	_step() {
+		local id="$1" msg="$2"; shift 2
+		if [ -n "$ABA_DEPLOY_DRY_RUN" ]; then
+			aba_info "DRY RUN [$id]: $*"
+			return 0
+		fi
+		local task="aba:deploy:$id"
+		# Resume semantics: run_once -S skips a COMPLETED step, but it also caches a
+		# FAILED step and would keep returning that cached failure. Reset a previously
+		# failed step so a re-run retries it, while completed steps stay skipped.
+		local prev_exit
+		prev_exit="$(run_once -E -i "$task" 2>/dev/null)"
+		[ -n "$prev_exit" ] && [ "$prev_exit" != "0" ] && run_once -r -i "$task" >/dev/null 2>&1
+		aba_info "==> $msg"
+		local rc=0
+		run_once -w -S -m "$msg" -i "$task" -- "$@" || rc=$?
+		[ "$rc" -eq 0 ] || aba_abort "aba deploy: step '$id' failed (exit $rc). Fix the problem and re-run 'aba deploy' to resume."
+		return 0
+	}
+
+	aba_info "Deploying: site='$site_dir' cluster='$cluster' platform='${platform:-unknown}'"
+
+	# 1-4: configs first (so nothing re-templates over them), then mirror, then ISO.
+	_step config-import  "Importing site configuration"                  "$aba_home/scripts/config-import.sh" import "$site_dir"
+	_step mirror-install "Installing/connecting the mirror registry"     make -C "$aba_home/mirror" install
+	_step mirror-load    "Loading images into the mirror registry"       make -C "$aba_home/mirror" load
+	_step iso            "Generating the agent-based ISO"                make -C "$aba_home/$cluster" iso
+
+	# Node boot gate. Hypervisors boot automatically; anything else (bare metal or
+	# unknown) pauses once after the ISO so the operator can boot the node(s).
+	if [ "$platform" != "vmw" ] && [ "$platform" != "kvm" ]; then
+		local _await="$aba_home/$cluster/.aba-deploy-await-boot"
+		if [ -n "$ABA_DEPLOY_DRY_RUN" ]; then
+			aba_info "DRY RUN [boot]: pause for manual node boot here, then re-run 'aba deploy' to resume"
+		elif [ ! -f "$_await" ]; then
+			: > "$_await"
+			aba_info_ok "ISO ready. Boot your node(s) from the ISO, then re-run 'aba deploy' to continue."
+			return 0
+		else
+			rm -f "$_await"
+			aba_info "Resuming after node boot; continuing to installation monitoring ..."
+		fi
+	fi
+
+	# Bring up + monitor. Hypervisors create/boot VMs and monitor via 'make install';
+	# bare metal (nodes already booted) just monitors via 'make mon'.
+	if [ "$platform" = "vmw" ] || [ "$platform" = "kvm" ]; then
+		_step install "Creating/booting VMs and monitoring the installation" make -C "$aba_home/$cluster" install
+	else
+		_step monitor "Monitoring the cluster installation"                  make -C "$aba_home/$cluster" mon
+	fi
+
+	# Day-2: mirror integration + waved custom manifests, run from the cluster dir.
+	[ -n "$ABA_DEPLOY_DRY_RUN" ] || cd "$aba_home/$cluster" 2>/dev/null || aba_abort "aba deploy: cluster directory not found: $aba_home/$cluster"
+	_step day2 "Applying day2 configuration (mirror integration + custom manifests)" "$aba_home/scripts/day2.sh"
+
+	aba_info_ok "Deployment steps complete for cluster '$cluster'."
+	return 0
+}
+
+# _detect_cluster <aba_home>: echo the single cluster dir (a subdir with
+# cluster.conf), or "" if none / abort if more than one.
+_detect_cluster() {
+	local home="$1" d name found=""
+	for d in "$home"/*/; do
+		[ -d "$d" ] || continue
+		[ -f "$d/cluster.conf" ] || continue
+		name="$(basename "$d")"
+		case "$name" in mirror|site|helm) continue ;; esac
+		[ -z "$found" ] || aba_abort "aba deploy: multiple clusters found; pick one with --cluster <name> or cluster_name in deploy.conf."
+		found="$name"
+	done
+	echo "$found"
+}
+
+# _detect_platform: echo the platform (vmw/kvm/bm) from aba.conf, or "".
+_detect_platform() {
+	( source <(normalize-aba-conf) 2>/dev/null; echo "$platform" )
+}
+
+# ---- run (the unit test extracts deploy_run and never reaches here) ----------
+aba_debug "Starting: $0 $*"
+
+aba_home="$PWD"   # header cd'd here (the aba root)
+site_dir="site"
+cluster_name=""
+[ -f deploy.conf ] && source ./deploy.conf   # optional descriptor: site_dir, cluster_name
+
+# Descriptor values (if set) become the defaults; CLI flags override below.
+_site="${site_dir:-site}"
+_cluster="${cluster_name:-}"
+
+while [ "$1" ]; do
+	case "$1" in
+		--site)    _site="$2"; shift 2 ;;
+		--cluster) _cluster="$2"; shift 2 ;;
+		--dry-run) export ABA_DEPLOY_DRY_RUN=1; shift ;;
+		import)    shift ;;   # tolerate a stray verb
+		*)         shift ;;
+	esac
+done
+
+[ -n "$_cluster" ] || _cluster="$(_detect_cluster "$aba_home")"
+_platform="$(_detect_platform)"
+
+deploy_run "$aba_home" "$_site" "$_cluster" "$_platform"

--- a/scripts/include_all.sh
+++ b/scripts/include_all.sh
@@ -995,9 +995,11 @@ _valid_cluster_name() {
 		return 1
 	fi
 
-	# Reserved ABA directories that must never be used as cluster names
+	# Reserved ABA directory/entry names and subcommands that must never be a cluster name.
+	# 'site' is the well-known config-import/bundle payload dir; 'aba'/'abatui'/'install'
+	# are top-level repo entries; 'config'/'deploy' are aba subcommands.
 	case "$name" in
-		mirror|scripts|cli|templates|tui|build|others|test|ai|tools|rpms|images|catalogs|bundles|docs|devel)
+		mirror|scripts|cli|templates|tui|build|others|test|ai|tools|rpms|images|catalogs|bundles|docs|devel|site|install|aba|abatui|config|deploy)
 			echo_red "Error: '$name' is a reserved ABA directory name — choose a different cluster name" >&2
 			return 1
 			;;

--- a/scripts/make-bundle.sh
+++ b/scripts/make-bundle.sh
@@ -84,6 +84,17 @@ _assemble_site() {
 	return 0
 }
 
+# _capture_site_isc: re-copy the just-regenerated imageset-config.yaml into the
+# site/ payload so the embedded copy matches the images 'make save' mirrored.
+# Matters with --complete --force, where the ISC is regenerated after assembly.
+_capture_site_isc() {
+	[ "$complete_bundle" ] || return 0
+	[ -f mirror/data/imageset-config.yaml ] || return 0
+	[ -d site ] || return 0
+	mkdir -p site/mirror
+	cp -f -- mirror/data/imageset-config.yaml site/mirror/imageset-config.yaml
+}
+
 aba_debug "Parsing command-line arguments: $#"
 while [[ $# -gt 0 ]]; do
 	case "$1" in
@@ -138,6 +149,15 @@ aba_debug "Configuration verified: ocp_version=$ocp_version ocp_channel=$ocp_cha
 # embeds it in the same tar (one archive carries the mirror AND the configs).
 # Clean it up on exit so a later plain 'aba bundle' is unchanged (no site/).
 if [ "$complete_bundle" ]; then
+	# Never destroy a pre-existing site/ (it may be the user's own deploy configs):
+	# move it aside to site.backup first, like config-import does for its targets.
+	if [ -e "$PWD/site" ]; then
+		aba_warning "An existing 'site/' directory was found; backing it up to 'site.backup' before assembling the bundle payload."
+		rm -rf -- "$PWD/site.backup"
+		mv -- "$PWD/site" "$PWD/site.backup"
+	fi
+	# Remove only the payload assembled here on exit, so a later plain 'aba bundle'
+	# is unchanged (site.backup is left untouched for the user to recover).
 	trap 'rm -rf -- "$PWD/site"' EXIT
 	aba_info "Assembling site/ config payload for --complete bundle ..."
 	_assemble_site "$PWD" "$PWD/site"
@@ -262,6 +282,7 @@ if [ "$bundle_dest_file" = "-" ]; then
 	aba_debug "All CLI tarballs downloaded"
 
 	aba_info "Writing install bundle (tar format) to stdout ..." >&2
+	_capture_site_isc
 	aba_debug "Calling: make -s tar out=-"
 	make -s tar out=-   # Be sure the output of this command is ONLY tar output!
 
@@ -306,6 +327,7 @@ if [ "$light_bundle" ]; then
 	
 	aba_info "Creating *light* install bundle archive ..."
 	rm -f "$bundle_dest_file"
+	_capture_site_isc
 	aba_debug "Calling: make tarrepo out=$bundle_dest_file"
 	make tarrepo out="$bundle_dest_file"			# Create install bundle containing the repo ONLY and excluding large imageset file(s).
 	aba_debug "Light bundle created successfully: $bundle_dest_file"
@@ -350,6 +372,7 @@ else
 	
 	aba_info "Creating install bundle archive ..."
 	rm -f "$bundle_dest_file"
+	_capture_site_isc
 	aba_debug "Calling: make tar out=$bundle_dest_file"
 	make tar out="$bundle_dest_file"	   		# Create all-in-one archive, including all files. 
 	aba_debug "Full bundle created successfully: $bundle_dest_file"

--- a/scripts/make-bundle.sh
+++ b/scripts/make-bundle.sh
@@ -165,7 +165,7 @@ if [ "$complete_bundle" ]; then
 		[ "$_user_site_saved" ] && [ -e "$_user_site_saved" ] && mv -- "$_user_site_saved" "$PWD/site"
 	}
 	trap _restore_user_site EXIT
-	aba_info "Assembling site/ config payload for --complete bundle ..."
+	aba_info "Assembling site/ config payload for --complete bundle ..." >&2
 	_assemble_site "$PWD" "$PWD/site"
 fi
 

--- a/scripts/make-bundle.sh
+++ b/scripts/make-bundle.sh
@@ -148,17 +148,24 @@ aba_debug "Configuration verified: ocp_version=$ocp_version ocp_channel=$ocp_cha
 # For --complete, assemble the site/ config payload into the repo so backup.sh
 # embeds it in the same tar (one archive carries the mirror AND the configs).
 # Clean it up on exit so a later plain 'aba bundle' is unchanged (no site/).
+complete_flag=
 if [ "$complete_bundle" ]; then
+	complete_flag="complete=--complete"   # tells 'make tar/tarrepo' -> backup.sh to include site/
 	# Never destroy a pre-existing site/ (it may be the user's own deploy configs):
-	# move it aside to site.backup first, like config-import does for its targets.
+	# move it aside, assemble the bundle payload, then RESTORE it on exit so the
+	# user's working tree is left exactly as it was.
+	_user_site_saved=
 	if [ -e "$PWD/site" ]; then
-		aba_warning "An existing 'site/' directory was found; backing it up to 'site.backup' before assembling the bundle payload."
-		rm -rf -- "$PWD/site.backup"
-		mv -- "$PWD/site" "$PWD/site.backup"
+		aba_warning "An existing 'site/' directory was found; it will be restored after the bundle is written."
+		rm -rf -- "$PWD/.site.aba-bundle-orig"
+		mv -- "$PWD/site" "$PWD/.site.aba-bundle-orig"
+		_user_site_saved=1
 	fi
-	# Remove only the payload assembled here on exit, so a later plain 'aba bundle'
-	# is unchanged (site.backup is left untouched for the user to recover).
-	trap 'rm -rf -- "$PWD/site"' EXIT
+	_restore_user_site() {
+		rm -rf -- "$PWD/site"
+		[ "$_user_site_saved" ] && [ -e "$PWD/.site.aba-bundle-orig" ] && mv -- "$PWD/.site.aba-bundle-orig" "$PWD/site"
+	}
+	trap _restore_user_site EXIT
 	aba_info "Assembling site/ config payload for --complete bundle ..."
 	_assemble_site "$PWD" "$PWD/site"
 fi
@@ -284,7 +291,7 @@ if [ "$bundle_dest_file" = "-" ]; then
 	aba_info "Writing install bundle (tar format) to stdout ..." >&2
 	_capture_site_isc
 	aba_debug "Calling: make -s tar out=-"
-	make -s tar out=-   # Be sure the output of this command is ONLY tar output!
+	make -s tar out=- $complete_flag   # Be sure the output of this command is ONLY tar output!
 
 	aba_debug "Stdout bundle creation complete, exiting"
 	exit
@@ -329,7 +336,7 @@ if [ "$light_bundle" ]; then
 	rm -f "$bundle_dest_file"
 	_capture_site_isc
 	aba_debug "Calling: make tarrepo out=$bundle_dest_file"
-	make tarrepo out="$bundle_dest_file"			# Create install bundle containing the repo ONLY and excluding large imageset file(s).
+	make tarrepo out="$bundle_dest_file" $complete_flag		# Create install bundle containing the repo ONLY and excluding large imageset file(s).
 	aba_debug "Light bundle created successfully: $bundle_dest_file"
 else
 	# Create a full install bundle containing the repo AND the image-set archive file(s) ...
@@ -374,7 +381,7 @@ else
 	rm -f "$bundle_dest_file"
 	_capture_site_isc
 	aba_debug "Calling: make tar out=$bundle_dest_file"
-	make tar out="$bundle_dest_file"	   		# Create all-in-one archive, including all files. 
+	make tar out="$bundle_dest_file" $complete_flag		# Create all-in-one archive, including all files.
 	aba_debug "Full bundle created successfully: $bundle_dest_file"
 fi
 

--- a/scripts/make-bundle.sh
+++ b/scripts/make-bundle.sh
@@ -43,6 +43,47 @@ _verify_cli_tarballs() {
 	aba_debug "All CLI tarballs passed integrity check (gzip -t)"
 }
 
+# _assemble_site <aba_root> <site_dir>
+# Collect the current aba configs into a site/ tree using the same layout that
+# 'aba config import' consumes, so 'aba bundle --complete' can embed one payload
+# carrying configs + helm charts + day2 manifests across the air gap.
+_assemble_site() {
+	local root="$1" site="$2" copied=0 f d name
+	rm -rf -- "$site"
+	mkdir -p "$site"
+
+	for f in aba.conf vmware.conf kvm.conf; do
+		[ -f "$root/$f" ] && { cp -f -- "$root/$f" "$site/$f"; copied=$((copied + 1)); }
+	done
+
+	if [ -f "$root/mirror/mirror.conf" ]; then
+		mkdir -p "$site/mirror"; cp -f -- "$root/mirror/mirror.conf" "$site/mirror/mirror.conf"; copied=$((copied + 1))
+	fi
+	if [ -f "$root/mirror/data/imageset-config.yaml" ]; then
+		mkdir -p "$site/mirror"; cp -f -- "$root/mirror/data/imageset-config.yaml" "$site/mirror/imageset-config.yaml"; copied=$((copied + 1))
+	fi
+
+	# A cluster directory is any subdir holding a cluster.conf (skip mirror/site/helm).
+	for d in "$root"/*/; do
+		[ -d "$d" ] || continue
+		name="$(basename "$d")"
+		case "$name" in mirror|site|helm) continue ;; esac
+		[ -f "$d/cluster.conf" ] || continue
+		mkdir -p "$site/$name"
+		cp -f -- "$d/cluster.conf" "$site/$name/cluster.conf"; copied=$((copied + 1))
+		[ -f "$d/install-config.yaml" ] && cp -f -- "$d/install-config.yaml" "$site/$name/install-config.yaml"
+		[ -f "$d/agent-config.yaml" ]   && cp -f -- "$d/agent-config.yaml"   "$site/$name/agent-config.yaml"
+		[ -f "$d/macs.conf" ]           && cp -f -- "$d/macs.conf"           "$site/$name/macs.conf"
+		[ -d "$d/day2-custom-manifests" ] && cp -a -- "$d/day2-custom-manifests" "$site/$name/day2-custom-manifests"
+	done
+
+	# Optional helm charts payload
+	[ -d "$root/helm" ] && cp -a -- "$root/helm" "$site/helm"
+
+	[ "$copied" -gt 0 ] || aba_warning "bundle --complete: no configs found to embed under $site"
+	return 0
+}
+
 aba_debug "Parsing command-line arguments: $#"
 while [[ $# -gt 0 ]]; do
 	case "$1" in
@@ -59,6 +100,11 @@ while [[ $# -gt 0 ]]; do
 		--light)
 			light_bundle=1
 			aba_debug "Argument: --light (exclude image-set archives)"
+			shift
+			;;
+		--complete)
+			complete_bundle=1
+			aba_debug "Argument: --complete (embed site/ config payload)"
 			shift
 			;;
 		*)
@@ -87,6 +133,15 @@ aba_debug "Normalizing and verifying aba.conf"
 source <(normalize-aba-conf)
 verify-aba-conf || aba_abort "$_ABA_CONF_ERR"
 aba_debug "Configuration verified: ocp_version=$ocp_version ocp_channel=$ocp_channel"
+
+# For --complete, assemble the site/ config payload into the repo so backup.sh
+# embeds it in the same tar (one archive carries the mirror AND the configs).
+# Clean it up on exit so a later plain 'aba bundle' is unchanged (no site/).
+if [ "$complete_bundle" ]; then
+	trap 'rm -rf -- "$PWD/site"' EXIT
+	aba_info "Assembling site/ config payload for --complete bundle ..."
+	_assemble_site "$PWD" "$PWD/site"
+fi
 
 if [ "$bundle_dest_file" = "-" ]; then
 	# Be sure the standard output of this command is ONLY tar output and nothing else!

--- a/scripts/make-bundle.sh
+++ b/scripts/make-bundle.sh
@@ -157,13 +157,12 @@ if [ "$complete_bundle" ]; then
 	_user_site_saved=
 	if [ -e "$PWD/site" ]; then
 		aba_warning "An existing 'site/' directory was found; it will be restored after the bundle is written."
-		rm -rf -- "$PWD/.site.aba-bundle-orig"
-		mv -- "$PWD/site" "$PWD/.site.aba-bundle-orig"
-		_user_site_saved=1
+		_user_site_saved="$PWD/.site.aba-bundle-orig.$$"   # unique path, never clobbers a prior save
+		mv -- "$PWD/site" "$_user_site_saved"
 	fi
 	_restore_user_site() {
 		rm -rf -- "$PWD/site"
-		[ "$_user_site_saved" ] && [ -e "$PWD/.site.aba-bundle-orig" ] && mv -- "$PWD/.site.aba-bundle-orig" "$PWD/site"
+		[ "$_user_site_saved" ] && [ -e "$_user_site_saved" ] && mv -- "$_user_site_saved" "$PWD/site"
 	}
 	trap _restore_user_site EXIT
 	aba_info "Assembling site/ config payload for --complete bundle ..."

--- a/templates/deploy.conf
+++ b/templates/deploy.conf
@@ -1,0 +1,17 @@
+# deploy.conf -- optional descriptor for 'aba deploy' (sourced, like aba.conf).
+#
+# 'aba deploy' runs a full air-gapped install as one resumable pipeline:
+#   config import -> mirror install -> mirror load -> iso -> (boot) -> monitor -> day2
+# Re-running 'aba deploy' skips completed steps and resumes where it stopped.
+#
+# All values below are optional. Without this file, deploy auto-detects the
+# single cluster directory and imports configs from ./site. CLI flags override
+# these values: aba deploy [--site <dir>] [--cluster <name>] [--dry-run]
+
+# Directory holding the configs to import (config import reads this verbatim).
+# Matches the layout produced by 'aba bundle --complete'.
+site_dir=site
+
+# Cluster directory to build. Leave empty to auto-detect (when there is exactly
+# one cluster directory in this aba installation).
+cluster_name=

--- a/templates/deploy.conf
+++ b/templates/deploy.conf
@@ -6,7 +6,8 @@
 #
 # All values below are optional. Without this file, deploy auto-detects the
 # single cluster directory and imports configs from ./site. CLI flags override
-# these values: aba deploy [--site <dir>] [--cluster <name>] [--dry-run]
+# these values: aba deploy [--site <dir>] [--cluster <name>] [--dry-run] [--restart]
+# (--restart clears cached step state for a fresh re-deploy, e.g. after a teardown.)
 
 # Directory holding the configs to import (config import reads this verbatim).
 # Matches the layout produced by 'aba bundle --complete'.

--- a/test/func/run-all-tests.sh
+++ b/test/func/run-all-tests.sh
@@ -55,6 +55,7 @@ unit_tests=(
 	test/func/test-replace-value-conf.sh
 	test/func/test-day2-waves.sh
 	test/func/test-config-import.sh
+	test/func/test-bundle-complete.sh
 	test/func/test-preflight-check-vsphere.sh
 	test/func/test-vmware-required-privileges.sh
 )

--- a/test/func/run-all-tests.sh
+++ b/test/func/run-all-tests.sh
@@ -53,6 +53,7 @@ unit_tests=(
 	test/func/test-resource-pool-resolution.sh
 	test/func/test-cluster-flag-forwarding.sh
 	test/func/test-replace-value-conf.sh
+	test/func/test-day2-waves.sh
 	test/func/test-preflight-check-vsphere.sh
 	test/func/test-vmware-required-privileges.sh
 )

--- a/test/func/run-all-tests.sh
+++ b/test/func/run-all-tests.sh
@@ -56,6 +56,7 @@ unit_tests=(
 	test/func/test-day2-waves.sh
 	test/func/test-config-import.sh
 	test/func/test-bundle-complete.sh
+	test/func/test-deploy.sh
 	test/func/test-preflight-check-vsphere.sh
 	test/func/test-vmware-required-privileges.sh
 )

--- a/test/func/run-all-tests.sh
+++ b/test/func/run-all-tests.sh
@@ -54,6 +54,7 @@ unit_tests=(
 	test/func/test-cluster-flag-forwarding.sh
 	test/func/test-replace-value-conf.sh
 	test/func/test-day2-waves.sh
+	test/func/test-config-import.sh
 	test/func/test-preflight-check-vsphere.sh
 	test/func/test-vmware-required-privileges.sh
 )

--- a/test/func/test-bundle-complete.sh
+++ b/test/func/test-bundle-complete.sh
@@ -110,21 +110,29 @@ _mk_repo() {			# $1 = fixture name  $2 = 1 to include a site/ payload
 	fi
 	echo "$r"
 }
-_run_backup() {			# $1 = repo root ; echoes tar path
-	local r="$1" out="$_tmp/$(basename "$(dirname "$1")").tar" home="$_tmp/home"
+_run_backup() {			# $1 = repo root ; $2 = optional backup.sh flags ; echoes tar path
+	local r="$1" flags="$2" out="$_tmp/$(basename "$(dirname "$1")").tar" home="$_tmp/home"
 	mkdir -p "$home"
-	( cd "$r" && HOME="$home" bash "$REPO_ROOT/scripts/backup.sh" "$out" ) >/dev/null 2>&1
+	( cd "$r" && HOME="$home" bash "$REPO_ROOT/scripts/backup.sh" $flags "$out" ) >/dev/null 2>&1
 	echo "$out"
 }
 
-_r_site="$(_mk_repo withsite 1)"; _t_site="$(_run_backup "$_r_site")"
+_r_site="$(_mk_repo withsite 1)"; _t_site="$(_run_backup "$_r_site" --complete)"
 if tar tf "$_t_site" 2>/dev/null | grep -q '^aba/site/'; then
-	test_pass "backup.sh embeds aba/site/... when a site/ payload exists"
+	test_pass "backup.sh embeds aba/site/... with --complete when a site/ payload exists"
 else
-	test_fail "site in tar" "aba/site/ not found in bundle tar"
+	test_fail "site in tar" "aba/site/ not found in --complete bundle tar"
 fi
 
-_r_none="$(_mk_repo nosite 0)"; _t_none="$(_run_backup "$_r_none")"
+# Security/no-regression: a plain bundle (NO --complete) must NOT sweep site/ in.
+_r_plain="$(_mk_repo plainsite 1)"; _t_plain="$(_run_backup "$_r_plain")"
+if tar tf "$_t_plain" 2>/dev/null | grep -q '^aba/site/'; then
+	test_fail "plain-bundle site leak" "aba/site/ included WITHOUT --complete (secret-bearing configs leaked)"
+else
+	test_pass "plain 'aba tar'/'aba bundle' excludes site/ (no secret leak without --complete)"
+fi
+
+_r_none="$(_mk_repo nosite 0)"; _t_none="$(_run_backup "$_r_none" --complete)"
 if tar tf "$_t_none" 2>/dev/null | grep -q '^aba/site/'; then
 	test_fail "no-regression" "aba/site/ present in tar without a site/ payload"
 else
@@ -142,9 +150,12 @@ grep -q '_assemble_site' scripts/make-bundle.sh \
 grep -q '\${repo_dir}/site' scripts/backup.sh \
 	&& test_pass "backup.sh conditionally includes \${repo_dir}/site" \
 	|| test_fail "backup site path" "backup.sh does not reference repo_dir/site"
-grep -q 'site.backup' scripts/make-bundle.sh \
-	&& test_pass "--complete backs up a pre-existing site/ instead of destroying it" \
-	|| test_fail "site backup" "make-bundle.sh does not preserve an existing site/"
+grep -q '_restore_user_site' scripts/make-bundle.sh \
+	&& test_pass "--complete preserves and restores a pre-existing user site/ (no data loss)" \
+	|| test_fail "site restore" "make-bundle.sh does not restore an existing site/"
+grep -q 'complete=--complete' scripts/make-bundle.sh \
+	&& test_pass "--complete threads the flag so backup.sh only includes site/ for --complete" \
+	|| test_fail "complete gate" "make-bundle.sh does not thread the --complete flag"
 grep -q '_capture_site_isc' scripts/make-bundle.sh \
 	&& test_pass "--complete re-captures the regenerated ISC into site/ after 'make save' (matches --force)" \
 	|| test_fail "isc recapture" "make-bundle.sh does not re-capture the ISC post-save"

--- a/test/func/test-bundle-complete.sh
+++ b/test/func/test-bundle-complete.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# Unit tests for 'aba bundle --complete': assemble a site/ payload (configs +
+# helm charts + day2 manifests) and embed it in the bundle tar so one archive
+# crosses the air gap and can be re-applied with 'aba config import'.
+#
+#   - _assemble_site() (in make-bundle.sh) collects the current configs into a
+#     site/ tree using the same layout 'aba config import' consumes.
+#   - backup.sh includes aba/site/... in the tar when a site/ dir is present,
+#     and leaves the tar unchanged when it is not (no regression).
+#   - export -> import round-trips the configs byte-for-byte.
+# No network, no oc; backup.sh runs against a minimal fixture with an isolated HOME.
+
+cd "$(dirname "$0")/../.."
+REPO_ROOT="$PWD"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+pass=0
+fail=0
+FAILURES=""
+
+test_pass() { echo -e "${GREEN}✓ PASS${NC}: $1"; pass=$(( pass + 1 )); }
+test_fail() { echo -e "${RED}✗ FAIL${NC}: $1 -- $2"; fail=$(( fail + 1 )); FAILURES=1; }
+
+_tmp=$(mktemp -d)
+trap 'rm -rf "$_tmp"' EXIT
+
+source scripts/include_all.sh dummy_arg 2>/dev/null
+
+# Load _assemble_site from make-bundle.sh and config_import_apply from config-import.sh.
+if grep -q '^_assemble_site() {' scripts/make-bundle.sh 2>/dev/null; then
+	eval "$(sed -n '/^_assemble_site() {/,/^}/p' scripts/make-bundle.sh)"
+fi
+[ -f scripts/config-import.sh ] && eval "$(sed -n '/^config_import_apply() {/,/^}/p' scripts/config-import.sh)"
+
+echo
+echo "=== Testing: aba bundle --complete (site payload) ==="
+echo
+
+_cmp() { if cmp -s "$2" "$3"; then test_pass "$1"; else test_fail "$1" "content differs ($2 vs $3)"; fi; }
+
+# --- build a representative aba tree (the connected/mirror side) ---------------
+_root="$_tmp/aba"
+mkdir -p "$_root/mirror/data" "$_root/mycluster/day2-custom-manifests/10-first" "$_root/helm" "$_root/scripts" "$_root/cli"
+printf 'ocp_version=4.19.2\nocp_channel=stable\n'      > "$_root/aba.conf"
+printf 'reg_host=registry.example.com\n'              > "$_root/mirror/mirror.conf"
+printf 'kind: ImageSetConfiguration\n'                > "$_root/mirror/data/imageset-config.yaml"
+printf 'name=mycluster\ntype=sno\n'                   > "$_root/mycluster/cluster.conf"
+printf 'apiVersion: v1\nkind: InstallConfig\n'        > "$_root/mycluster/install-config.yaml"
+printf 'apiVersion: v1alpha1\nkind: AgentConfig\n'    > "$_root/mycluster/agent-config.yaml"
+printf '52:54:00:aa:bb:cc\n'                          > "$_root/mycluster/macs.conf"
+printf 'apiVersion: v1\nkind: ConfigMap\n'            > "$_root/mycluster/day2-custom-manifests/10-first/app.yaml"
+printf 'chart: demo\n'                                > "$_root/helm/Chart.yaml"
+# noise: a non-cluster dir (no cluster.conf) must NOT be treated as a cluster
+printf 'not a cluster\n'                              > "$_root/scripts/helper.sh"
+
+# --- Test group 1: _assemble_site collects configs into the site/ layout ------
+echo "--- _assemble_site layout ---"
+if ! type _assemble_site >/dev/null 2>&1; then
+	test_fail "_assemble_site exists" "make-bundle.sh has no _assemble_site() function yet (red)"
+else
+	_site="$_root/site"
+	( _assemble_site "$_root" "$_site" ) >/dev/null 2>&1
+	_cmp "site/aba.conf"                       "$_root/aba.conf"                     "$_site/aba.conf"
+	_cmp "site/mirror/mirror.conf"             "$_root/mirror/mirror.conf"           "$_site/mirror/mirror.conf"
+	_cmp "site/mirror/imageset-config.yaml"    "$_root/mirror/data/imageset-config.yaml" "$_site/mirror/imageset-config.yaml"
+	_cmp "site/<cluster>/cluster.conf"         "$_root/mycluster/cluster.conf"       "$_site/mycluster/cluster.conf"
+	_cmp "site/<cluster>/install-config.yaml"  "$_root/mycluster/install-config.yaml" "$_site/mycluster/install-config.yaml"
+	_cmp "site/<cluster>/agent-config.yaml"    "$_root/mycluster/agent-config.yaml"  "$_site/mycluster/agent-config.yaml"
+	_cmp "site/<cluster>/macs.conf"            "$_root/mycluster/macs.conf"          "$_site/mycluster/macs.conf"
+	_cmp "site/<cluster>/day2 manifest"        "$_root/mycluster/day2-custom-manifests/10-first/app.yaml" "$_site/mycluster/day2-custom-manifests/10-first/app.yaml"
+	_cmp "site/helm/Chart.yaml"                "$_root/helm/Chart.yaml"              "$_site/helm/Chart.yaml"
+	if [ ! -e "$_site/scripts" ]; then
+		test_pass "non-cluster dir (scripts/) not embedded as a cluster"
+	else
+		test_fail "cluster detection" "scripts/ wrongly embedded in site/"
+	fi
+fi
+
+# --- Test group 2: export -> import round-trips byte-for-byte ------------------
+echo "--- export -> import round-trip ---"
+if type _assemble_site >/dev/null 2>&1 && type config_import_apply >/dev/null 2>&1; then
+	_dest="$_tmp/dest"
+	mkdir -p "$_dest"
+	( config_import_apply "$_root/site" "$_dest" ) >/dev/null 2>&1
+	_cmp "round-trip aba.conf"                 "$_root/aba.conf"                     "$_dest/aba.conf"
+	_cmp "round-trip imageset-config.yaml"     "$_root/mirror/data/imageset-config.yaml" "$_dest/mirror/data/imageset-config.yaml"
+	_cmp "round-trip install-config.yaml"      "$_root/mycluster/install-config.yaml" "$_dest/mycluster/install-config.yaml"
+	_cmp "round-trip day2 manifest"            "$_root/mycluster/day2-custom-manifests/10-first/app.yaml" "$_dest/mycluster/day2-custom-manifests/10-first/app.yaml"
+else
+	test_fail "round-trip" "_assemble_site and/or config_import_apply unavailable (red)"
+fi
+
+# --- Test group 3: backup.sh embeds aba/site/... in the tar (real run) --------
+echo "--- backup.sh tar inclusion ---"
+_mk_repo() {			# $1 = fixture name  $2 = 1 to include a site/ payload
+	local r="$_tmp/$1/aba"
+	mkdir -p "$r/scripts"
+	ln -s "$REPO_ROOT/scripts"/* "$r/scripts/" 2>/dev/null
+	( cd "$r"
+	  : > install; : > aba; : > aba.conf; : > Makefile; : > README.md; : > VERSION
+	  : > CHANGELOG.md; : > LICENSE; : > Troubleshooting.md; : > .index
+	  mkdir -p cli rpms others templates tui/v2 mirror )
+	if [ "$2" = "1" ]; then
+		mkdir -p "$r/site/mycluster"
+		printf 'ocp_version=4.19.2\n' > "$r/site/aba.conf"
+		printf 'name=mycluster\n'     > "$r/site/mycluster/cluster.conf"
+	fi
+	echo "$r"
+}
+_run_backup() {			# $1 = repo root ; echoes tar path
+	local r="$1" out="$_tmp/$(basename "$(dirname "$1")").tar" home="$_tmp/home"
+	mkdir -p "$home"
+	( cd "$r" && HOME="$home" bash "$REPO_ROOT/scripts/backup.sh" "$out" ) >/dev/null 2>&1
+	echo "$out"
+}
+
+_r_site="$(_mk_repo withsite 1)"; _t_site="$(_run_backup "$_r_site")"
+if tar tf "$_t_site" 2>/dev/null | grep -q '^aba/site/'; then
+	test_pass "backup.sh embeds aba/site/... when a site/ payload exists"
+else
+	test_fail "site in tar" "aba/site/ not found in bundle tar"
+fi
+
+_r_none="$(_mk_repo nosite 0)"; _t_none="$(_run_backup "$_r_none")"
+if tar tf "$_t_none" 2>/dev/null | grep -q '^aba/site/'; then
+	test_fail "no-regression" "aba/site/ present in tar without a site/ payload"
+else
+	test_pass "no site/ payload -> tar has no aba/site/ (no regression)"
+fi
+
+# --- Test group 4: make-bundle.sh flag wiring ---------------------------------
+echo "--- --complete flag wiring ---"
+grep -qE '\-\-complete\)' scripts/make-bundle.sh \
+	&& test_pass "make-bundle.sh parses --complete" \
+	|| test_fail "flag parse" "--complete not handled in make-bundle.sh"
+grep -q '_assemble_site' scripts/make-bundle.sh \
+	&& test_pass "make-bundle.sh calls _assemble_site" \
+	|| test_fail "assembly call" "_assemble_site not invoked in make-bundle.sh"
+grep -q '\${repo_dir}/site' scripts/backup.sh \
+	&& test_pass "backup.sh conditionally includes \${repo_dir}/site" \
+	|| test_fail "backup site path" "backup.sh does not reference repo_dir/site"
+
+echo
+echo "=== Results: $pass passed, $fail failed ==="
+echo
+
+[ -z "$FAILURES" ] && exit 0 || exit 1

--- a/test/func/test-bundle-complete.sh
+++ b/test/func/test-bundle-complete.sh
@@ -142,6 +142,12 @@ grep -q '_assemble_site' scripts/make-bundle.sh \
 grep -q '\${repo_dir}/site' scripts/backup.sh \
 	&& test_pass "backup.sh conditionally includes \${repo_dir}/site" \
 	|| test_fail "backup site path" "backup.sh does not reference repo_dir/site"
+grep -q 'site.backup' scripts/make-bundle.sh \
+	&& test_pass "--complete backs up a pre-existing site/ instead of destroying it" \
+	|| test_fail "site backup" "make-bundle.sh does not preserve an existing site/"
+grep -q '_capture_site_isc' scripts/make-bundle.sh \
+	&& test_pass "--complete re-captures the regenerated ISC into site/ after 'make save' (matches --force)" \
+	|| test_fail "isc recapture" "make-bundle.sh does not re-capture the ISC post-save"
 
 echo
 echo "=== Results: $pass passed, $fail failed ==="

--- a/test/func/test-config-import.sh
+++ b/test/func/test-config-import.sh
@@ -167,6 +167,25 @@ _am=$(stat -c %Y "$_dest2/prod/install-config.yaml")
 [ "$_bm" = "$_am" ] && test_pass "importing c1 does not re-stamp the unrelated cluster prod/" \
 	|| test_fail "pin scoping" "prod/install-config.yaml mtime changed ($_bm -> $_am)"
 
+# --- Test group 8: .backup keeps the ORIGINAL across repeated imports ---------
+echo "--- backup rotation ---"
+_rot="$_tmp/rot"; mkdir -p "$_rot/mycluster"
+printf 'ORIGINAL\n' > "$_rot/mycluster/install-config.yaml"
+( config_import_apply "$_site" "$_rot" ) >/dev/null 2>&1
+( config_import_apply "$_site" "$_rot" ) >/dev/null 2>&1
+grep -q ORIGINAL "$_rot/mycluster/install-config.yaml.backup" 2>/dev/null \
+	&& test_pass "re-import preserves the pre-aba original in .backup (no rotation clobber)" \
+	|| test_fail "backup rotation" "original lost from .backup after two imports"
+
+# --- Test group 9: config import scaffolds the cluster dir (Makefile + init) ---
+echo "--- cluster scaffold wiring ---"
+grep -q 'Makefile.cluster' "$REPO_ROOT/scripts/config-import.sh" \
+	&& test_pass "config import creates the cluster Makefile symlink (make can run)" \
+	|| test_fail "scaffold Makefile" "no Makefile.cluster symlink in config-import.sh"
+grep -qE 'make -s?C? *-?[sC]* *-C "\$_cname" init|make -s -C "\$_cname" init' "$REPO_ROOT/scripts/config-import.sh" \
+	&& test_pass "config import runs 'make init' to create scripts/mirror/aba.conf symlinks" \
+	|| test_fail "scaffold init" "config-import.sh does not run 'make init' on cluster dirs"
+
 # --- Test group 5: CLI dispatch wiring (aba config import <dir>) --------------
 echo "--- dispatch wiring ---"
 grep -q '|config|' scripts/aba.sh \

--- a/test/func/test-config-import.sh
+++ b/test/func/test-config-import.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# Unit tests for config-import: copy site/ configs VERBATIM into an aba tree and
+# pin regeneration guards so aba never re-templates over the imported files.
+#
+# Guards under test (verified against the real code):
+#   - imageset-config.yaml must be STRICTLY newer than mirror/data/.created
+#     (reg-create-imageset-config.sh skips regen when ISC -nt .created).
+#   - install-config.yaml / agent-config.yaml must be STRICTLY newer than their
+#     Make prerequisites cluster.conf and mirror.conf (Makefile.cluster) so make
+#     treats them as up-to-date and does not regenerate them.
+# Pure filesystem: no oc, no make, no network.
+
+cd "$(dirname "$0")/../.."
+REPO_ROOT="$PWD"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+pass=0
+fail=0
+FAILURES=""
+
+test_pass() { echo -e "${GREEN}✓ PASS${NC}: $1"; pass=$(( pass + 1 )); }
+test_fail() { echo -e "${RED}✗ FAIL${NC}: $1 -- $2"; fail=$(( fail + 1 )); FAILURES=1; }
+
+_tmp=$(mktemp -d)
+trap 'rm -rf "$_tmp"' EXIT
+
+source scripts/include_all.sh dummy_arg 2>/dev/null
+
+# Load the function under test (config-import.sh guards main behind a source
+# check, but extracting the function keeps the test focused and fast).
+if [ ! -f scripts/config-import.sh ]; then
+	echo "FATAL: scripts/config-import.sh does not exist yet (red)" >&2
+	echo "=== Results: 0 passed, 1 failed ==="
+	exit 1
+fi
+eval "$(sed -n '/^config_import_apply() {/,/^}/p' scripts/config-import.sh)"
+if ! type config_import_apply >/dev/null 2>&1; then
+	echo "FATAL: could not extract config_import_apply() from scripts/config-import.sh" >&2
+	exit 1
+fi
+
+echo
+echo "=== Testing: config_import_apply() ==="
+echo
+
+# --- build a representative site/ fixture -------------------------------------
+_site="$_tmp/site"
+mkdir -p "$_site/mirror" "$_site/mycluster/day2-custom-manifests/10-first"
+printf 'ocp_version=4.19.2\nocp_channel=stable\n'          > "$_site/aba.conf"
+printf 'reg_host=registry.example.com\nreg_port=8443\n'    > "$_site/mirror/mirror.conf"
+printf 'kind: ImageSetConfiguration\napiVersion: v1\n'     > "$_site/mirror/imageset-config.yaml"
+printf 'name=mycluster\ntype=sno\n'                        > "$_site/mycluster/cluster.conf"
+printf 'apiVersion: v1\nkind: InstallConfig\n'             > "$_site/mycluster/install-config.yaml"
+printf 'apiVersion: v1alpha1\nkind: AgentConfig\n'         > "$_site/mycluster/agent-config.yaml"
+printf '52:54:00:aa:bb:cc\n'                               > "$_site/mycluster/macs.conf"
+printf 'apiVersion: v1\nkind: ConfigMap\n'                 > "$_site/mycluster/day2-custom-manifests/10-first/app.yaml"
+
+_dest="$_tmp/aba"
+mkdir -p "$_dest"
+( config_import_apply "$_site" "$_dest" ) >/dev/null 2>&1
+_import_rc=$?
+
+# --- Test group 1: files copied byte-for-byte ---------------------------------
+echo "--- verbatim copy (cmp) ---"
+_cmp() {			# name  src  dest
+	if cmp -s "$2" "$3"; then test_pass "$1"; else test_fail "$1" "content differs (src=$2 dest=$3)"; fi
+}
+_cmp "aba.conf copied verbatim"            "$_site/aba.conf"                       "$_dest/aba.conf"
+_cmp "mirror.conf copied verbatim"         "$_site/mirror/mirror.conf"             "$_dest/mirror/mirror.conf"
+_cmp "imageset-config.yaml copied verbatim" "$_site/mirror/imageset-config.yaml"   "$_dest/mirror/data/imageset-config.yaml"
+_cmp "cluster.conf copied verbatim"        "$_site/mycluster/cluster.conf"         "$_dest/mycluster/cluster.conf"
+_cmp "install-config.yaml copied verbatim" "$_site/mycluster/install-config.yaml"  "$_dest/mycluster/install-config.yaml"
+_cmp "agent-config.yaml copied verbatim"   "$_site/mycluster/agent-config.yaml"    "$_dest/mycluster/agent-config.yaml"
+_cmp "macs.conf copied verbatim"           "$_site/mycluster/macs.conf"            "$_dest/mycluster/macs.conf"
+_cmp "day2 wave manifest copied verbatim"  "$_site/mycluster/day2-custom-manifests/10-first/app.yaml" "$_dest/mycluster/day2-custom-manifests/10-first/app.yaml"
+
+# --- Test group 2: regeneration guards (mtime ordering) -----------------------
+echo "--- regeneration guards (strict mtime) ---"
+if [ "$_dest/mirror/data/imageset-config.yaml" -nt "$_dest/mirror/data/.created" ]; then
+	test_pass "imageset-config.yaml is strictly newer than mirror/data/.created (ISC pinned)"
+else
+	test_fail "ISC pin" "imageset-config.yaml is not newer than .created"
+fi
+if [ "$_dest/mycluster/install-config.yaml" -nt "$_dest/mycluster/cluster.conf" ]; then
+	test_pass "install-config.yaml newer than cluster.conf (no make regen)"
+else
+	test_fail "install-config vs cluster.conf" "not newer"
+fi
+if [ "$_dest/mycluster/install-config.yaml" -nt "$_dest/mirror/mirror.conf" ]; then
+	test_pass "install-config.yaml newer than mirror.conf (no make regen)"
+else
+	test_fail "install-config vs mirror.conf" "not newer"
+fi
+if [ "$_dest/mycluster/agent-config.yaml" -nt "$_dest/mycluster/cluster.conf" ]; then
+	test_pass "agent-config.yaml newer than cluster.conf (no make regen)"
+else
+	test_fail "agent-config vs cluster.conf" "not newer"
+fi
+if [ "$_dest/mycluster/agent-config.yaml" -nt "$_dest/mirror/mirror.conf" ]; then
+	test_pass "agent-config.yaml newer than mirror.conf (no make regen)"
+else
+	test_fail "agent-config vs mirror.conf" "not newer"
+fi
+
+# --- Test group 3: overall success + existing-file backup ---------------------
+echo "--- success + backup ---"
+[ "$_import_rc" -eq 0 ] && test_pass "config_import_apply returns 0 on a valid site" \
+	|| test_fail "import rc" "expected 0 got $_import_rc"
+
+# Re-import over an existing tree: previous install-config should be backed up.
+printf 'apiVersion: v1\nkind: InstallConfig\nCHANGED: yes\n' > "$_site/mycluster/install-config.yaml"
+( config_import_apply "$_site" "$_dest" ) >/dev/null 2>&1
+if [ -f "$_dest/mycluster/install-config.yaml.backup" ]; then
+	test_pass "existing install-config.yaml backed up to .backup on re-import"
+else
+	test_fail "backup on re-import" "no .backup file created"
+fi
+_cmp "re-import overwrites with new content" "$_site/mycluster/install-config.yaml" "$_dest/mycluster/install-config.yaml"
+
+# --- Test group 4: error handling ---------------------------------------------
+echo "--- error handling ---"
+( config_import_apply "$_tmp/does-not-exist" "$_dest" ) >/dev/null 2>&1
+[ $? -ne 0 ] && test_pass "missing source directory aborts (non-zero)" \
+	|| test_fail "missing source" "expected non-zero exit"
+
+_empty="$_tmp/empty-site"
+mkdir -p "$_empty"
+( config_import_apply "$_empty" "$_dest" ) >/dev/null 2>&1
+[ $? -ne 0 ] && test_pass "source with no recognized configs aborts (non-zero)" \
+	|| test_fail "empty source" "expected non-zero exit"
+
+# --- Test group 5: CLI dispatch wiring (aba config import <dir>) --------------
+echo "--- dispatch wiring ---"
+grep -q '|config|' scripts/aba.sh \
+	&& test_pass "'config' is in the aba direct-dispatch allow-list" \
+	|| test_fail "allow-list" "config missing from aba.sh direct-dispatch list"
+grep -qE '^[[:space:]]*config\)' scripts/aba.sh \
+	&& test_pass "aba.sh has a 'config)' dispatch arm" \
+	|| test_fail "dispatch arm" "no config) arm in aba.sh"
+grep -q 'scripts/config-import.sh' scripts/aba.sh \
+	&& test_pass "config) arm invokes config-import.sh" \
+	|| test_fail "arm target" "config) does not call config-import.sh"
+grep -q 'subcmd_args' scripts/aba.sh \
+	&& test_pass "config positional args routed via subcmd_args (not BUILD_COMMAND)" \
+	|| test_fail "arg routing" "subcmd_args not wired in aba.sh"
+grep -q 'aba config import' others/help-aba.txt \
+	&& test_pass "help-aba.txt documents 'aba config import'" \
+	|| test_fail "help text" "config import not documented in help-aba.txt"
+
+echo
+echo "=== Results: $pass passed, $fail failed ==="
+echo
+
+[ -z "$FAILURES" ] && exit 0 || exit 1

--- a/test/func/test-config-import.sh
+++ b/test/func/test-config-import.sh
@@ -206,6 +206,74 @@ grep -q 'aba config import' others/help-aba.txt \
 	&& test_pass "help-aba.txt documents 'aba config import'" \
 	|| test_fail "help text" "config import not documented in help-aba.txt"
 
+# --- Test group 6: robustness fixes (partial/malformed payloads) --------------
+echo "--- robustness: validation, error handling, scoped pins ---"
+_mkf() { mkdir -p "$(dirname "$1")"; printf '%s\n' "$2" > "$1"; }
+
+# M5: an invalid/reserved cluster-dir name aborts BEFORE anything is copied.
+_g="$_tmp/g6"; rm -rf "$_g"; _s5="$_g/site"; _d5="$_g/dest"; mkdir -p "$_d5"
+_mkf "$_s5/aba.conf" "ocp_version=NEW"; _mkf "$_s5/alpha/cluster.conf" "x"; _mkf "$_s5/zz.bad/cluster.conf" "x"
+_mkf "$_d5/aba.conf" "ocp_version=ORIG"
+( config_import_apply "$_s5" "$_d5" ) >/dev/null 2>&1
+if grep -q ORIG "$_d5/aba.conf" && [ ! -e "$_d5/aba.conf.backup" ] && [ ! -d "$_d5/alpha" ]; then
+	test_pass "invalid cluster name aborts before any copy (no half-import)"
+else
+	test_fail "M5 pre-validation" "tree mutated before abort"
+fi
+
+# M6: a failed copy aborts loudly instead of reporting success.
+_s6="$_g/site6"; _d6="$_g/dest6"; mkdir -p "$_d6"; _mkf "$_s6/aba.conf" "x"
+: > "$_d6/aba.conf.backup"; chmod 000 "$_d6" 2>/dev/null
+_o6="$( ( config_import_apply "$_s6" "$_d6" ) 2>&1 )"; _r6=$?
+chmod 755 "$_d6" 2>/dev/null
+if [ "$_r6" -ne 0 ] && printf '%s' "$_o6" | grep -qiE 'failed|cannot'; then
+	test_pass "a failed copy aborts (no false 'imported' success)"
+else
+	test_fail "M6 error handling" "silent success on copy failure (rc=$_r6)"
+fi
+
+# M10: a helm-only payload imports successfully (not a false 'no configs' abort).
+_s10="$_g/site10"; _d10="$_g/dest10"; mkdir -p "$_d10"; _mkf "$_s10/helm/values.yaml" "payload"
+_o10="$( ( config_import_apply "$_s10" "$_d10" ) 2>&1 )"; _r10=$?
+if [ "$_r10" -eq 0 ] && grep -q payload "$_d10/helm/values.yaml" && ! printf '%s' "$_o10" | grep -qi 'no recognized'; then
+	test_pass "helm-only payload imports without a false 'no configs' error"
+else
+	test_fail "M10 helm-only" "rc=$_r10 out=$_o10"
+fi
+
+# M2: a partial payload (only macs.conf) must not rewind or re-pin a user's own
+# pre-existing cluster.conf / mirror.conf / install-config.yaml.
+_d2="$_g/dest2"; mkdir -p "$_d2/mirror" "$_d2/sno"
+_mkf "$_d2/mirror/mirror.conf" "m"; _mkf "$_d2/sno/cluster.conf" "c"; _mkf "$_d2/sno/install-config.yaml" "generated"
+touch -d '2 hours ago' "$_d2/sno/install-config.yaml"
+_cc0=$(stat -c %Y "$_d2/sno/cluster.conf"); _mc0=$(stat -c %Y "$_d2/mirror/mirror.conf"); _ic0=$(stat -c %Y "$_d2/sno/install-config.yaml")
+_s2="$_g/site2"; _mkf "$_s2/sno/macs.conf" "aa:bb"
+( config_import_apply "$_s2" "$_d2" ) >/dev/null 2>&1
+if [ "$_cc0" = "$(stat -c %Y "$_d2/sno/cluster.conf")" ] && [ "$_mc0" = "$(stat -c %Y "$_d2/mirror/mirror.conf")" ] && [ "$_ic0" = "$(stat -c %Y "$_d2/sno/install-config.yaml")" ]; then
+	test_pass "partial payload leaves non-imported files' mtimes untouched"
+else
+	test_fail "M2 scoped pins" "non-imported file mtimes were mutated"
+fi
+
+# L6: 'site' and top-level repo entries are reserved cluster names.
+if ! _valid_cluster_name site >/dev/null 2>&1 && ! _valid_cluster_name aba >/dev/null 2>&1; then
+	test_pass "'site' and 'aba' are rejected as cluster names"
+else
+	test_fail "L6 reserved names" "'site'/'aba' accepted as a cluster name"
+fi
+
+# H1: the scaffold re-pins cluster.conf AFTER 'make init' (which creates a fresh
+# .init) and BEFORE the install/agent touches, so the next make does not re-template.
+_ci="$REPO_ROOT/scripts/config-import.sh"
+_l_init=$(grep -n 'make -s -C "\$_cname" init' "$_ci" | head -1 | cut -d: -f1)
+_l_cc=$(grep -n 'touch "\$_cname/cluster.conf"' "$_ci" | head -1 | cut -d: -f1)
+_l_ic=$(grep -n 'touch "\$_cname/install-config.yaml"' "$_ci" | head -1 | cut -d: -f1)
+if [ -n "$_l_init" ] && [ -n "$_l_cc" ] && [ -n "$_l_ic" ] && [ "$_l_init" -lt "$_l_cc" ] && [ "$_l_cc" -lt "$_l_ic" ]; then
+	test_pass "scaffold re-touches cluster.conf after 'make init', before install/agent (H1 guard)"
+else
+	test_fail "H1 scaffold re-pin" "cluster.conf not re-touched between make init and install touch (init=$_l_init cc=$_l_cc ic=$_l_ic)"
+fi
+
 echo
 echo "=== Results: $pass passed, $fail failed ==="
 echo

--- a/test/func/test-config-import.sh
+++ b/test/func/test-config-import.sh
@@ -274,6 +274,14 @@ else
 	test_fail "H1 scaffold re-pin" "cluster.conf not re-touched between make init and install touch (init=$_l_init cc=$_l_cc ic=$_l_ic)"
 fi
 
+# H1b: the scaffold touches must be GATED on what was imported ($_src), so a
+# cluster.conf-only import never re-stamps (pins) a pre-existing generated install-config.
+if grep -qE '\[ -f "\$_src/\$_cname/install-config\.yaml" \][[:space:]]*&&[[:space:]]*touch "\$_cname/install-config\.yaml"' "$_ci"; then
+	test_pass "scaffold install-config touch is gated on \$_src (no stale-config pin)"
+else
+	test_fail "H1b scaffold gating" "scaffold touches install-config unconditionally (would pin a stale generated config)"
+fi
+
 echo
 echo "=== Results: $pass passed, $fail failed ==="
 echo

--- a/test/func/test-config-import.sh
+++ b/test/func/test-config-import.sh
@@ -132,6 +132,41 @@ mkdir -p "$_empty"
 [ $? -ne 0 ] && test_pass "source with no recognized configs aborts (non-zero)" \
 	|| test_fail "empty source" "expected non-zero exit"
 
+# --- Test group 6: directory payloads are backed up on re-import (no data loss)
+echo "--- directory payload backup ---"
+printf 'PRECIOUS\n' > "$_dest/mycluster/day2-custom-manifests/10-first/precious.yaml"
+printf 'apiVersion: v1\nkind: ConfigMap\nchanged: yes\n' > "$_site/mycluster/day2-custom-manifests/10-first/app.yaml"
+( config_import_apply "$_site" "$_dest" ) >/dev/null 2>&1
+if [ -f "$_dest/mycluster/day2-custom-manifests.backup/10-first/precious.yaml" ]; then
+	test_pass "existing day2-custom-manifests backed up to .backup on re-import"
+else
+	test_fail "day2 dir backup" "precious.yaml not preserved in .backup"
+fi
+
+# --- Test group 7: pin never creates empty trigger files or touches other clusters
+echo "--- pin no-create + scoping ---"
+_dest2="$_tmp/aba2"
+_site2="$_tmp/site2"
+mkdir -p "$_dest2" "$_site2/c1"
+printf 'name=c1\n'                              > "$_site2/c1/cluster.conf"
+printf 'apiVersion: v1\nkind: InstallConfig\n'  > "$_site2/c1/install-config.yaml"
+( config_import_apply "$_site2" "$_dest2" ) >/dev/null 2>&1
+if [ ! -e "$_dest2/mirror/mirror.conf" ]; then
+	test_pass "pin does not inject an empty mirror/mirror.conf when the payload has none"
+else
+	test_fail "no-create mirror.conf" "empty mirror.conf injected"
+fi
+# a pre-existing UNRELATED cluster must not be re-stamped when importing c1
+mkdir -p "$_dest2/prod"
+printf 'name=prod\n'  > "$_dest2/prod/cluster.conf"
+printf 'IC\n'        > "$_dest2/prod/install-config.yaml"
+touch -d '2 minutes ago' "$_dest2/prod/install-config.yaml"
+_bm=$(stat -c %Y "$_dest2/prod/install-config.yaml")
+( config_import_apply "$_site2" "$_dest2" ) >/dev/null 2>&1
+_am=$(stat -c %Y "$_dest2/prod/install-config.yaml")
+[ "$_bm" = "$_am" ] && test_pass "importing c1 does not re-stamp the unrelated cluster prod/" \
+	|| test_fail "pin scoping" "prod/install-config.yaml mtime changed ($_bm -> $_am)"
+
 # --- Test group 5: CLI dispatch wiring (aba config import <dir>) --------------
 echo "--- dispatch wiring ---"
 grep -q '|config|' scripts/aba.sh \

--- a/test/func/test-config-import.sh
+++ b/test/func/test-config-import.sh
@@ -134,13 +134,15 @@ mkdir -p "$_empty"
 
 # --- Test group 6: directory payloads are backed up on re-import (no data loss)
 echo "--- directory payload backup ---"
-printf 'PRECIOUS\n' > "$_dest/mycluster/day2-custom-manifests/10-first/precious.yaml"
-printf 'apiVersion: v1\nkind: ConfigMap\nchanged: yes\n' > "$_site/mycluster/day2-custom-manifests/10-first/app.yaml"
-( config_import_apply "$_site" "$_dest" ) >/dev/null 2>&1
-if [ -f "$_dest/mycluster/day2-custom-manifests.backup/10-first/precious.yaml" ]; then
-	test_pass "existing day2-custom-manifests backed up to .backup on re-import"
+# Fresh dest with a pre-existing day2 dir; import twice - .backup must keep the ORIGINAL.
+_dd="$_tmp/dirbak"; mkdir -p "$_dd/mycluster/day2-custom-manifests/10-first"
+printf 'PRECIOUS\n' > "$_dd/mycluster/day2-custom-manifests/10-first/precious.yaml"
+( config_import_apply "$_site" "$_dd" ) >/dev/null 2>&1
+( config_import_apply "$_site" "$_dd" ) >/dev/null 2>&1
+if grep -q PRECIOUS "$_dd/mycluster/day2-custom-manifests.backup/10-first/precious.yaml" 2>/dev/null; then
+	test_pass "existing day2-custom-manifests backed up once to .backup (original preserved across re-imports)"
 else
-	test_fail "day2 dir backup" "precious.yaml not preserved in .backup"
+	test_fail "day2 dir backup" "original precious.yaml not preserved in .backup"
 fi
 
 # --- Test group 7: pin never creates empty trigger files or touches other clusters

--- a/test/func/test-day2-waves.sh
+++ b/test/func/test-day2-waves.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+# Unit tests for day2 apply_custom_manifests() WAVED-manifest behavior.
+#
+# A "wave" is a numbered subdirectory (NN-name/) of day2-custom-manifests/.
+# Waves are applied in NUMERIC order (so 2 before 10), and an optional per-wave
+# '.wait' file makes day2 run 'oc wait <condition>' before starting the next wave.
+# Flat (unprefixed) files must still be applied exactly as before (backward compat).
+#
+# No real cluster is available: 'oc' is stubbed via a PATH shim that just logs its
+# arguments to a file, so we can assert the ORDER of apply/wait calls.
+
+cd "$(dirname "$0")/../.."
+REPO_ROOT="$PWD"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+pass=0
+fail=0
+FAILURES=""
+
+test_pass() { echo -e "${GREEN}✓ PASS${NC}: $1"; pass=$(( pass + 1 )); }
+test_fail() { echo -e "${RED}✗ FAIL${NC}: $1 -- $2"; fail=$(( fail + 1 )); FAILURES=1; }
+
+_tmp=$(mktemp -d)
+trap 'rm -rf "$_tmp"' EXIT
+
+# Load aba helpers (aba_info / aba_debug / aba_warning / aba_info_ok)
+source scripts/include_all.sh dummy_arg 2>/dev/null
+
+# day2.sh executes a whole pipeline when sourced, so we cannot source it. Extract
+# just the apply_custom_manifests() definition and eval it to test in isolation.
+_fn_src="$(sed -n '/^apply_custom_manifests() {/,/^}/p' scripts/day2.sh)"
+eval "$_fn_src"
+if ! type apply_custom_manifests >/dev/null 2>&1; then
+	echo "FATAL: could not extract apply_custom_manifests() from scripts/day2.sh" >&2
+	exit 1
+fi
+
+# --- oc PATH shim: log every 'oc ...' call to $OC_LOG, with failure injection ---
+_shim_dir="$_tmp/bin"
+mkdir -p "$_shim_dir"
+cat > "$_shim_dir/oc" <<'MOCK'
+#!/bin/bash
+echo "oc $*" >> "$OC_LOG"
+verb="$1"
+if [ "$verb" = "apply" ]; then
+	f="${@: -1}"							# manifest path is the last arg
+	if [ -n "$OC_APPLY_FAIL_ON" ] && [[ "$f" == *"$OC_APPLY_FAIL_ON"* ]]; then
+		exit 1
+	fi
+	exit 0
+fi
+if [ "$verb" = "wait" ]; then
+	[ -n "$OC_WAIT_FAIL" ] && exit 1
+	exit 0
+fi
+exit 0
+MOCK
+chmod +x "$_shim_dir/oc"
+export PATH="$_shim_dir:$PATH"
+
+# --- helpers ------------------------------------------------------------------
+
+_mk() {									# create a non-empty manifest at $1
+	mkdir -p "$(dirname "$1")"
+	printf 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: %s\n' "$(basename "$1")" > "$1"
+}
+
+_LAST_LOG=""
+_LAST_RC=""
+_run_apply() {								# $1 = cluster dir
+	local dir="$1"
+	_LAST_LOG="$_tmp/order-$RANDOM.log"
+	: > "$_LAST_LOG"
+	local rc=0
+	( export OC_LOG="$_LAST_LOG"; cd "$dir" && apply_custom_manifests ) >/dev/null 2>&1 || rc=$?
+	_LAST_RC="$rc"
+}
+
+_apply_line() {								# echo first line no. of 'apply ... $2'
+	grep -n "apply .*$2" "$1" 2>/dev/null | head -1 | cut -d: -f1
+}
+
+_assert_before() {							# name log fileA fileB
+	local name="$1" log="$2" a="$3" b="$4" la lb
+	la="$(_apply_line "$log" "$a")"
+	lb="$(_apply_line "$log" "$b")"
+	if [ -n "$la" ] && [ -n "$lb" ] && [ "$la" -lt "$lb" ]; then
+		test_pass "$name"
+	else
+		test_fail "$name" "expected $a(line=${la:-none}) before $b(line=${lb:-none}); log: $(tr '\n' '|' <"$log")"
+	fi
+}
+
+_assert_applied() {							# name log basename
+	if grep -q "apply .*$3" "$2"; then
+		test_pass "$1"
+	else
+		test_fail "$1" "$3 not applied; log: $(tr '\n' '|' <"$2")"
+	fi
+}
+
+_assert_wait_between() {						# name log fileA waitPat fileB
+	local name="$1" log="$2" a="$3" pat="$4" b="$5" la lw lb
+	la="$(_apply_line "$log" "$a")"
+	lw="$(grep -n "wait .*$pat" "$log" 2>/dev/null | head -1 | cut -d: -f1)"
+	lb="$(_apply_line "$log" "$b")"
+	if [ -n "$la" ] && [ -n "$lw" ] && [ -n "$lb" ] && [ "$la" -lt "$lw" ] && [ "$lw" -lt "$lb" ]; then
+		test_pass "$name"
+	else
+		test_fail "$name" "expected apply($a)=$la < wait=$lw < apply($b)=$lb; log: $(tr '\n' '|' <"$log")"
+	fi
+}
+
+echo
+echo "=== Testing: day2 apply_custom_manifests() waves ==="
+echo
+
+# --- Test A: waves applied in NUMERIC order (lexicographic would put 10 before 2)
+echo "--- Test A: numeric wave ordering ---"
+fxA="$_tmp/clusterA"
+_mk "$fxA/day2-custom-manifests/2-early/early.yaml"
+_mk "$fxA/day2-custom-manifests/10-first/first.yaml"
+_mk "$fxA/day2-custom-manifests/20-third/third.yaml"
+_run_apply "$fxA"
+_assert_before "wave 2 applied before wave 10 (numeric, not lexicographic)" "$_LAST_LOG" "early.yaml" "first.yaml"
+_assert_before "wave 10 applied before wave 20" "$_LAST_LOG" "first.yaml" "third.yaml"
+
+# --- Test B: per-wave .wait triggers 'oc wait' BEFORE the next wave
+echo "--- Test B: .wait gates the next wave ---"
+fxB="$_tmp/clusterB"
+_mk "$fxB/day2-custom-manifests/10-one/one.yaml"
+printf -- '--for=condition=Established crd/widgets.example.com --timeout=60s\n' > "$fxB/day2-custom-manifests/10-one/.wait"
+_mk "$fxB/day2-custom-manifests/20-two/two.yaml"
+_run_apply "$fxB"
+_assert_wait_between ".wait runs 'oc wait' between wave 10 and wave 20" "$_LAST_LOG" "one.yaml" "widgets.example.com" "two.yaml"
+
+# --- Test C: flat/unprefixed files still applied (backward compatible)
+echo "--- Test C: flat files (legacy layout) still apply ---"
+fxC="$_tmp/clusterC"
+_mk "$fxC/day2-custom-manifests/aaa.yaml"
+_mk "$fxC/day2-custom-manifests/bbb.yml"
+_run_apply "$fxC"
+_assert_applied "flat aaa.yaml applied" "$_LAST_LOG" "aaa.yaml"
+_assert_applied "flat bbb.yml applied" "$_LAST_LOG" "bbb.yml"
+
+# --- Test C2: top-level flat files applied even when waves are present
+echo "--- Test C2: flat + waves mixed layout ---"
+fxC2="$_tmp/clusterC2"
+_mk "$fxC2/day2-custom-manifests/top.yaml"
+_mk "$fxC2/day2-custom-manifests/10-w/w.yaml"
+_run_apply "$fxC2"
+_assert_applied "top-level flat file applied in waved layout" "$_LAST_LOG" "top.yaml"
+_assert_applied "wave file applied in waved layout" "$_LAST_LOG" "w.yaml"
+
+# --- Test D: empty / missing directory is a no-op (existing behavior preserved)
+echo "--- Test D: empty/missing is a no-op ---"
+fxD="$_tmp/clusterD"
+mkdir -p "$fxD"
+_run_apply "$fxD"
+if [ ! -s "$_LAST_LOG" ] && [ "$_LAST_RC" -eq 0 ]; then
+	test_pass "missing day2-custom-manifests: no oc calls, rc=0"
+else
+	test_fail "missing day2-custom-manifests no-op" "rc=$_LAST_RC log=$(tr '\n' '|' <"$_LAST_LOG")"
+fi
+fxD2="$_tmp/clusterD2"
+mkdir -p "$fxD2/day2-custom-manifests"
+_run_apply "$fxD2"
+if [ ! -s "$_LAST_LOG" ] && [ "$_LAST_RC" -eq 0 ]; then
+	test_pass "empty day2-custom-manifests: no oc calls, rc=0"
+else
+	test_fail "empty day2-custom-manifests no-op" "rc=$_LAST_RC log=$(tr '\n' '|' <"$_LAST_LOG")"
+fi
+
+# --- Test E: a failed 'oc apply' is non-fatal (return 0, keep going)
+echo "--- Test E: apply failure is non-fatal ---"
+fxE="$_tmp/clusterE"
+_mk "$fxE/day2-custom-manifests/10-a/bad.yaml"
+_mk "$fxE/day2-custom-manifests/20-b/good.yaml"
+export OC_APPLY_FAIL_ON="bad.yaml"
+_run_apply "$fxE"
+unset OC_APPLY_FAIL_ON
+if [ "$_LAST_RC" -eq 0 ]; then
+	test_pass "apply failure keeps rc=0 (non-fatal)"
+else
+	test_fail "apply failure non-fatal" "rc=$_LAST_RC"
+fi
+_assert_applied "next wave still applied after a failed apply" "$_LAST_LOG" "good.yaml"
+
+# --- Test F: an 'oc wait' timeout is non-fatal and does not block later waves
+echo "--- Test F: wait timeout is non-fatal ---"
+fxF="$_tmp/clusterF"
+_mk "$fxF/day2-custom-manifests/10-a/a.yaml"
+printf -- '--for=condition=Ready pod/foo --timeout=1s\n' > "$fxF/day2-custom-manifests/10-a/.wait"
+_mk "$fxF/day2-custom-manifests/20-b/b.yaml"
+export OC_WAIT_FAIL=1
+_run_apply "$fxF"
+unset OC_WAIT_FAIL
+if [ "$_LAST_RC" -eq 0 ]; then
+	test_pass "wait timeout keeps rc=0 (non-fatal)"
+else
+	test_fail "wait timeout non-fatal" "rc=$_LAST_RC"
+fi
+_assert_applied "next wave still applied after a wait timeout" "$_LAST_LOG" "b.yaml"
+
+echo
+echo "=== Results: $pass passed, $fail failed ==="
+echo
+
+[ -z "$FAILURES" ] && exit 0 || exit 1

--- a/test/func/test-day2-waves.sh
+++ b/test/func/test-day2-waves.sh
@@ -261,6 +261,18 @@ else
 	test_fail ".wait bad quote" "oc wait ran on an unparseable line: $(grep wait "$_LAST_LOG" | tr '\n' '|')"
 fi
 
+# L3b: a '#' inside a BALANCED quoted value must be preserved (not treated as a
+# comment and truncated), so the wait line still runs.
+fxM="$_tmp/clusterM"
+_mk "$fxM/day2-custom-manifests/10-w/a.yaml"
+printf -- "--for=condition=Ready --selector='app=web #1' pod/foo\n" > "$fxM/day2-custom-manifests/10-w/.wait"
+_run_apply "$fxM"
+if grep -q 'wait .*app=web #1' "$_LAST_LOG" && ! grep -q 'cannot parse' "$_LAST_LOG"; then
+	test_pass "quoted '#' in a .wait value is preserved (wait not skipped/truncated)"
+else
+	test_fail ".wait quoted-hash" "quoted value truncated or line skipped: $(tr '\n' '|' <"$_LAST_LOG")"
+fi
+
 # M4: an unreadable .wait must be non-fatal even under 'set -e' (day2.sh is bash -e):
 # the gate is skipped and later waves still apply (no whole-run abort).
 fxL="$_tmp/clusterL"

--- a/test/func/test-day2-waves.sh
+++ b/test/func/test-day2-waves.sh
@@ -205,6 +205,29 @@ else
 fi
 _assert_applied "next wave still applied after a wait timeout" "$_LAST_LOG" "b.yaml"
 
+# --- Test G: waved mode still applies non-numbered subdir manifests -----------
+echo "--- waved mode keeps non-wave subdir manifests (no silent drop) ---"
+fxG="$_tmp/clusterG"
+_mk "$fxG/day2-custom-manifests/10-app/app.yaml"
+_mk "$fxG/day2-custom-manifests/base/storageclass.yaml"
+_run_apply "$fxG"
+_assert_applied "waved mode: wave manifest applied"                          "$_LAST_LOG" "app.yaml"
+_assert_applied "waved mode: non-numbered subdir manifest applied (kept)"    "$_LAST_LOG" "storageclass.yaml"
+
+# --- Test H: an indented .wait comment is ignored, not passed to 'oc wait' -----
+echo "--- .wait indented comment ignored ---"
+fxH="$_tmp/clusterH"
+_mk "$fxH/day2-custom-manifests/10-a/a.yaml"
+printf '  # just a comment\n--for=condition=Ready pod/foo\n' > "$fxH/day2-custom-manifests/10-a/.wait"
+_mk "$fxH/day2-custom-manifests/20-b/b.yaml"
+_run_apply "$fxH"
+if grep -q 'wait .*comment' "$_LAST_LOG"; then
+	test_fail ".wait indented comment ignored" "comment was passed to oc wait: $(grep wait "$_LAST_LOG" | tr '\n' '|')"
+else
+	test_pass ".wait indented comment ignored (not passed to oc wait)"
+fi
+grep -q 'wait .*pod/foo' "$_LAST_LOG" && test_pass ".wait real condition still honored" || test_fail ".wait real condition" "pod/foo wait missing"
+
 echo
 echo "=== Results: $pass passed, $fail failed ==="
 echo

--- a/test/func/test-day2-waves.sh
+++ b/test/func/test-day2-waves.sh
@@ -228,6 +228,14 @@ else
 fi
 grep -q 'wait .*pod/foo' "$_LAST_LOG" && test_pass ".wait real condition still honored" || test_fail ".wait real condition" "pod/foo wait missing"
 
+# --- Test I: top-level numbered files order by number relative to waves --------
+echo "--- numeric ordering across waves and top-level files ---"
+fxI="$_tmp/clusterI"
+_mk "$fxI/day2-custom-manifests/10-operators/op.yaml"
+_mk "$fxI/day2-custom-manifests/99-postconfig.yaml"
+_run_apply "$fxI"
+_assert_before "wave 10-operators applied before top-level 99-postconfig.yaml (legacy order kept)" "$_LAST_LOG" "op.yaml" "99-postconfig.yaml"
+
 echo
 echo "=== Results: $pass passed, $fail failed ==="
 echo

--- a/test/func/test-day2-waves.sh
+++ b/test/func/test-day2-waves.sh
@@ -236,6 +236,47 @@ _mk "$fxI/day2-custom-manifests/99-postconfig.yaml"
 _run_apply "$fxI"
 _assert_before "wave 10-operators applied before top-level 99-postconfig.yaml (legacy order kept)" "$_LAST_LOG" "op.yaml" "99-postconfig.yaml"
 
+# --- Test J: .wait robustness (trailing comment, bad quotes, unreadable file) --
+echo "--- .wait parsing robustness ---"
+
+# L3: a trailing '# comment' must be stripped, not passed to oc wait as argv.
+fxJ="$_tmp/clusterJ"
+_mk "$fxJ/day2-custom-manifests/10-w/a.yaml"
+printf -- '--for=condition=Ready pod/foo --timeout=5s # wait for foo\n' > "$fxJ/day2-custom-manifests/10-w/.wait"
+_run_apply "$fxJ"
+if grep -q 'wait .*pod/foo' "$_LAST_LOG" && ! grep -q 'wait .*comment' "$_LAST_LOG" && ! grep -q 'wait .*#' "$_LAST_LOG"; then
+	test_pass ".wait trailing '# comment' stripped before oc wait"
+else
+	test_fail ".wait trailing comment" "comment leaked to oc wait: $(grep wait "$_LAST_LOG" | tr '\n' '|')"
+fi
+
+# L2: a line xargs cannot parse (unbalanced quote) is skipped, not run truncated.
+fxK="$_tmp/clusterK"
+_mk "$fxK/day2-custom-manifests/10-w/a.yaml"
+printf -- "--for=condition=Ready pod/foo --timeout=5s'\n" > "$fxK/day2-custom-manifests/10-w/.wait"
+_run_apply "$fxK"
+if grep -q 'apply .*a.yaml' "$_LAST_LOG" && ! grep -q '^oc wait' "$_LAST_LOG"; then
+	test_pass "unbalanced-quote .wait line skipped (oc wait not run with truncated argv)"
+else
+	test_fail ".wait bad quote" "oc wait ran on an unparseable line: $(grep wait "$_LAST_LOG" | tr '\n' '|')"
+fi
+
+# M4: an unreadable .wait must be non-fatal even under 'set -e' (day2.sh is bash -e):
+# the gate is skipped and later waves still apply (no whole-run abort).
+fxL="$_tmp/clusterL"
+_mk "$fxL/day2-custom-manifests/10-w/a.yaml"
+_mk "$fxL/day2-custom-manifests/20-w/b.yaml"
+printf -- '--for=condition=Ready pod/foo\n' > "$fxL/day2-custom-manifests/10-w/.wait"
+chmod 000 "$fxL/day2-custom-manifests/10-w/.wait"
+_LAST_LOG="$_tmp/order-e.log"; : > "$_LAST_LOG"; _erc=0
+( set -e; export OC_LOG="$_LAST_LOG"; cd "$fxL" && apply_custom_manifests ) >/dev/null 2>&1 || _erc=$?
+chmod 644 "$fxL/day2-custom-manifests/10-w/.wait" 2>/dev/null
+if [ "$_erc" -eq 0 ] && grep -q 'apply .*a.yaml' "$_LAST_LOG" && grep -q 'apply .*b.yaml' "$_LAST_LOG"; then
+	test_pass "unreadable .wait is non-fatal under set -e (later waves still apply)"
+else
+	test_fail "M4 unreadable .wait" "run aborted (rc=$_erc) or wave 20 skipped: $(tr '\n' '|' <"$_LAST_LOG")"
+fi
+
 echo
 echo "=== Results: $pass passed, $fail failed ==="
 echo

--- a/test/func/test-deploy.sh
+++ b/test/func/test-deploy.sh
@@ -228,6 +228,12 @@ grep -q 'unexpected argument' "$REPO_ROOT/scripts/deploy.sh" \
 grep -qE '\-n\|--name\)' "$REPO_ROOT/scripts/deploy.sh" \
 	&& test_pass "deploy accepts aba's '-n <name>' cluster syntax" \
 	|| test_fail "name syntax" "no -n/--name handling"
+grep -qE '_cluster="\$1"' "$REPO_ROOT/scripts/deploy.sh" \
+	&& test_pass "a lone positional is taken as the cluster name (aba deploy <cluster>)" \
+	|| test_fail "positional cluster" "bare positional not mapped to --cluster"
+grep -q '_site_cli' "$REPO_ROOT/scripts/deploy.sh" \
+	&& test_pass "only a CLI --site is resolved vs caller cwd (deploy.conf site_dir stays aba-root anchored)" \
+	|| test_fail "site_dir anchoring" "deploy.conf relative site_dir wrongly resolved against caller cwd"
 
 # --- Test 9: --restart is atomic (interrupted restart cannot skip later steps) -
 echo "--- --restart atomicity (interrupted restart -> plain resume) ---"

--- a/test/func/test-deploy.sh
+++ b/test/func/test-deploy.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# Unit tests for the 'aba deploy' orchestrator (scripts/deploy.sh).
+#
+# deploy_run() runs the air-gapped install as an ordered, idempotent, resumable
+# pipeline: config import -> mirror install -> mirror load -> iso -> (boot) ->
+# monitor -> day2. Steps are wrapped in run_once -S so a re-run skips completed
+# steps (resume). ABA_DEPLOY_DRY_RUN=1 prints the plan and executes nothing.
+#
+# No real cluster/registry: 'make' is stubbed via a PATH shim and the aba
+# sub-scripts are stubbed under a temp ABA_ROOT; run_once state is isolated via
+# RUN_ONCE_DIR.
+
+cd "$(dirname "$0")/../.."
+REPO_ROOT="$PWD"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+pass=0
+fail=0
+FAILURES=""
+
+test_pass() { echo -e "${GREEN}✓ PASS${NC}: $1"; pass=$(( pass + 1 )); }
+test_fail() { echo -e "${RED}✗ FAIL${NC}: $1 -- $2"; fail=$(( fail + 1 )); FAILURES=1; }
+
+_tmp=$(mktemp -d)
+trap 'rm -rf "$_tmp"' EXIT
+
+source scripts/include_all.sh dummy_arg 2>/dev/null
+export INFO_ABA=1   # deploy_run uses aba_info (gated on INFO_ABA); enable it for plan capture
+
+if [ ! -f scripts/deploy.sh ]; then
+	echo "FATAL: scripts/deploy.sh does not exist yet (red)" >&2
+	echo "=== Results: 0 passed, 1 failed ==="
+	exit 1
+fi
+eval "$(sed -n '/^deploy_run() {/,/^}/p' scripts/deploy.sh)"
+if ! type deploy_run >/dev/null 2>&1; then
+	echo "FATAL: could not extract deploy_run() from scripts/deploy.sh" >&2
+	exit 1
+fi
+
+# --- fake ABA_ROOT with stub sub-scripts + PATH-stubbed make ------------------
+_root="$_tmp/aba"
+mkdir -p "$_root/scripts" "$_root/mirror" "$_root/mycluster" "$_tmp/bin" "$_tmp/runner"
+: > "$_root/mycluster/cluster.conf"
+export ABA_ROOT="$_root"
+export RUN_ONCE_DIR="$_tmp/runner"
+export DEPLOY_LOG="$_tmp/order.log"
+
+cat > "$_root/scripts/config-import.sh" <<'EOF'
+#!/bin/bash
+echo "config-import $*" >> "$DEPLOY_LOG"
+EOF
+cat > "$_root/scripts/day2.sh" <<'EOF'
+#!/bin/bash
+echo "day2 $*" >> "$DEPLOY_LOG"
+EOF
+chmod +x "$_root/scripts/config-import.sh" "$_root/scripts/day2.sh"
+
+cat > "$_tmp/bin/make" <<'EOF'
+#!/bin/bash
+echo "make $*" >> "$DEPLOY_LOG"
+if [ -n "$MAKE_FAIL_ON" ]; then
+	case "$*" in *"$MAKE_FAIL_ON"*) exit 1 ;; esac
+fi
+exit 0
+EOF
+chmod +x "$_tmp/bin/make"
+export PATH="$_tmp/bin:$PATH"
+
+_reset_state() { : > "$DEPLOY_LOG"; rm -rf "$RUN_ONCE_DIR"; mkdir -p "$RUN_ONCE_DIR"; rm -f "$_root/mycluster/.aba-deploy-await-boot"; }
+_line() { grep -n "$2" "$1" 2>/dev/null | head -1 | cut -d: -f1; }        # first line matching $2 in file $1
+_before() {			# name  file  patA  patB
+	local la lb; la="$(_line "$2" "$3")"; lb="$(_line "$2" "$4")"
+	if [ -n "$la" ] && [ -n "$lb" ] && [ "$la" -lt "$lb" ]; then test_pass "$1"; else test_fail "$1" "$3(=$la) not before $4(=$lb)"; fi
+}
+_has() { if grep -q "$3" "$2"; then test_pass "$1"; else test_fail "$1" "missing: $3"; fi; }
+_hasnot() { if grep -q "$3" "$2"; then test_fail "$1" "unexpected: $3"; else test_pass "$1"; fi; }
+
+echo
+echo "=== Testing: aba deploy orchestrator ==="
+echo
+
+# --- Test 1: DRY RUN prints the full ordered plan and executes nothing --------
+echo "--- dry-run plan (bare-metal) ---"
+_reset_state
+_plan="$_tmp/plan-bm.txt"
+( ABA_DEPLOY_DRY_RUN=1 deploy_run "$_root" "site" "mycluster" "bm" ) > "$_plan" 2>&1
+_before "plan: config-import before mirror-install" "$_plan" 'config-import' 'mirror-install'
+_before "plan: mirror-install before mirror-load"   "$_plan" 'mirror-install' 'mirror-load'
+_before "plan: mirror-load before iso"              "$_plan" 'mirror-load' 'iso'
+_before "plan: iso before monitor"                  "$_plan" '\[iso\]' 'monitor'
+_before "plan: monitor before day2"                 "$_plan" 'monitor' 'day2'
+_has    "plan: bare-metal boot pause noted"         "$_plan" 'boot'
+if [ ! -s "$DEPLOY_LOG" ]; then test_pass "dry-run executes nothing (no make/sub-scripts)"; else test_fail "dry-run side effects" "$(tr '\n' '|' <"$DEPLOY_LOG")"; fi
+if [ ! -d "$RUN_ONCE_DIR" ] || [ -z "$(ls -A "$RUN_ONCE_DIR" 2>/dev/null)" ]; then test_pass "dry-run creates no run_once state"; else test_fail "dry-run run_once state" "state created"; fi
+
+# --- Test 2: hypervisor plan uses 'make install' (auto VM boot), no pause -----
+echo "--- dry-run plan (hypervisor) ---"
+_reset_state
+_planv="$_tmp/plan-vmw.txt"
+( ABA_DEPLOY_DRY_RUN=1 deploy_run "$_root" "site" "mycluster" "vmw" ) > "$_planv" 2>&1
+_has "vmw plan: uses 'make ... install' for bring-up" "$_planv" 'install'
+_before "vmw plan: iso before install" "$_planv" '\[iso\]' '\[install\]'
+_before "vmw plan: install before day2" "$_planv" '\[install\]' 'day2'
+
+# --- Test 3: real execution order (hypervisor, straight through) --------------
+echo "--- execution order (vmw) ---"
+_reset_state
+( deploy_run "$_root" "site" "mycluster" "vmw" ) >/dev/null 2>&1
+_before "exec: config-import first"        "$DEPLOY_LOG" 'config-import' 'mirror install'
+_before "exec: mirror install before load" "$DEPLOY_LOG" 'mirror install' 'mirror load'
+_before "exec: mirror load before iso"     "$DEPLOY_LOG" 'mirror load' 'mycluster iso'
+_before "exec: iso before cluster install" "$DEPLOY_LOG" 'mycluster iso' 'mycluster install'
+_before "exec: cluster install before day2" "$DEPLOY_LOG" 'mycluster install' 'day2'
+
+# --- Test 4: resume - re-run skips completed steps (run_once -S) --------------
+echo "--- resume (idempotent) ---"
+_reset_state
+( deploy_run "$_root" "site" "mycluster" "vmw" ) >/dev/null 2>&1
+_n1=$(wc -l < "$DEPLOY_LOG")
+( deploy_run "$_root" "site" "mycluster" "vmw" ) >/dev/null 2>&1
+_n2=$(wc -l < "$DEPLOY_LOG")
+if [ "$_n1" -gt 0 ] && [ "$_n2" -eq "$_n1" ]; then
+	test_pass "re-run skips completed steps (no re-execution): $_n1 == $_n2"
+else
+	test_fail "resume" "expected no growth; first=$_n1 second=$_n2"
+fi
+
+# --- Test 5: a failed step halts the pipeline ---------------------------------
+echo "--- failure stops pipeline ---"
+_reset_state
+( MAKE_FAIL_ON="mirror load" deploy_run "$_root" "site" "mycluster" "vmw" ) >/dev/null 2>&1
+_drc=$?
+_has    "failure: reached mirror load"        "$DEPLOY_LOG" 'mirror load'
+_hasnot "failure: iso NOT run after failure"  "$DEPLOY_LOG" 'mycluster iso'
+_hasnot "failure: day2 NOT run after failure" "$DEPLOY_LOG" 'day2'
+[ "$_drc" -ne 0 ] && test_pass "deploy_run returns non-zero on step failure" || test_fail "failure rc" "expected non-zero"
+
+# --- Test 6: bare-metal pause then resume -------------------------------------
+echo "--- bare-metal pause/resume ---"
+_reset_state
+( deploy_run "$_root" "site" "mycluster" "bm" ) >/dev/null 2>&1
+_has    "bm run 1: iso generated"                 "$DEPLOY_LOG" 'mycluster iso'
+_hasnot "bm run 1: pauses before monitor"         "$DEPLOY_LOG" 'mycluster mon'
+_hasnot "bm run 1: pauses before day2"            "$DEPLOY_LOG" 'day2'
+[ -f "$_root/mycluster/.aba-deploy-await-boot" ] && test_pass "bm run 1: await-boot marker created" || test_fail "bm marker" "no marker"
+( deploy_run "$_root" "site" "mycluster" "bm" ) >/dev/null 2>&1
+_has "bm run 2: resumes into monitor" "$DEPLOY_LOG" 'mycluster mon'
+_has "bm run 2: runs day2 after monitor" "$DEPLOY_LOG" 'day2'
+
+# --- Test 6b: a fixed step retries on re-run (not stuck on cached failure) -----
+echo "--- fix-and-resume (retry a failed step) ---"
+_reset_state
+( MAKE_FAIL_ON="mirror load" deploy_run "$_root" "site" "mycluster" "vmw" ) >/dev/null 2>&1
+_hasnot "fix-resume run 1: iso not reached (load failed)" "$DEPLOY_LOG" 'mycluster iso'
+( deploy_run "$_root" "site" "mycluster" "vmw" ) >/dev/null 2>&1
+_has "fix-resume run 2: previously-failed load retried, iso reached" "$DEPLOY_LOG" 'mycluster iso'
+_has "fix-resume run 2: pipeline completes through day2"             "$DEPLOY_LOG" 'day2'
+
+# --- Test 7: CLI dispatch wiring ----------------------------------------------
+echo "--- dispatch wiring ---"
+grep -q '|deploy|' "$REPO_ROOT/scripts/aba.sh" && test_pass "'deploy' in direct-dispatch allow-list" || test_fail "allow-list" "deploy missing"
+grep -qE '^[[:space:]]*deploy\)' "$REPO_ROOT/scripts/aba.sh" && test_pass "aba.sh has a 'deploy)' arm" || test_fail "arm" "no deploy) arm"
+grep -q 'scripts/deploy.sh' "$REPO_ROOT/scripts/aba.sh" && test_pass "deploy) arm invokes deploy.sh" || test_fail "arm target" "no deploy.sh call"
+grep -q 'aba deploy' "$REPO_ROOT/others/help-aba.txt" && test_pass "help-aba.txt documents 'aba deploy'" || test_fail "help" "not documented"
+
+echo
+echo "=== Results: $pass passed, $fail failed ==="
+echo
+
+[ -z "$FAILURES" ] && exit 0 || exit 1

--- a/test/func/test-deploy.sh
+++ b/test/func/test-deploy.sh
@@ -167,6 +167,18 @@ grep -qE '^[[:space:]]*deploy\)' "$REPO_ROOT/scripts/aba.sh" && test_pass "aba.s
 grep -q 'scripts/deploy.sh' "$REPO_ROOT/scripts/aba.sh" && test_pass "deploy) arm invokes deploy.sh" || test_fail "arm target" "no deploy.sh call"
 grep -q 'aba deploy' "$REPO_ROOT/others/help-aba.txt" && test_pass "help-aba.txt documents 'aba deploy'" || test_fail "help" "not documented"
 
+# --- Test 8: arg-parsing hardening --------------------------------------------
+echo "--- arg-parsing hardening ---"
+grep -q 'requires a value' "$REPO_ROOT/scripts/deploy.sh" \
+	&& test_pass "deploy validates --site/--cluster values (no infinite loop on missing value)" \
+	|| test_fail "value check" "missing --site/--cluster value guard"
+grep -q 'unknown option' "$REPO_ROOT/scripts/deploy.sh" \
+	&& test_pass "deploy rejects unknown flags (a typo'd --dry-run is not silently ignored)" \
+	|| test_fail "unknown flag" "no --* rejection"
+grep -q '"$home/$site"' "$REPO_ROOT/scripts/deploy.sh" \
+	&& test_pass "cluster auto-detect falls back to the site payload (works before import)" \
+	|| test_fail "detect fallback" "no site-payload fallback in _detect_cluster"
+
 echo
 echo "=== Results: $pass passed, $fail failed ==="
 echo

--- a/test/func/test-deploy.sh
+++ b/test/func/test-deploy.sh
@@ -118,17 +118,19 @@ _before "exec: mirror load before iso"     "$DEPLOY_LOG" 'mirror load' 'mycluste
 _before "exec: iso before cluster install" "$DEPLOY_LOG" 'mycluster iso' 'mycluster install'
 _before "exec: cluster install before day2" "$DEPLOY_LOG" 'mycluster install' 'day2'
 
-# --- Test 4: resume - re-run skips completed steps (run_once -S) --------------
+# --- Test 4: resume - re-run skips the expensive cached steps (run_once -S) ----
+# (config-import is intentionally always-run/idempotent, so assert the costly
+#  make steps run exactly once across two invocations.)
 echo "--- resume (idempotent) ---"
 _reset_state
 ( deploy_run "$_root" "site" "mycluster" "vmw" ) >/dev/null 2>&1
-_n1=$(wc -l < "$DEPLOY_LOG")
 ( deploy_run "$_root" "site" "mycluster" "vmw" ) >/dev/null 2>&1
-_n2=$(wc -l < "$DEPLOY_LOG")
-if [ "$_n1" -gt 0 ] && [ "$_n2" -eq "$_n1" ]; then
-	test_pass "re-run skips completed steps (no re-execution): $_n1 == $_n2"
+_iso_n=$(grep -c 'mycluster iso' "$DEPLOY_LOG")
+_mir_n=$(grep -c 'mirror install' "$DEPLOY_LOG")
+if [ "$_iso_n" -eq 1 ] && [ "$_mir_n" -eq 1 ]; then
+	test_pass "re-run skips cached make steps (iso ran ${_iso_n}x, mirror-install ${_mir_n}x across 2 runs)"
 else
-	test_fail "resume" "expected no growth; first=$_n1 second=$_n2"
+	test_fail "resume" "expected iso=1 mirror-install=1; got iso=$_iso_n mirror-install=$_mir_n"
 fi
 
 # --- Test 5: a failed step halts the pipeline ---------------------------------

--- a/test/func/test-deploy.sh
+++ b/test/func/test-deploy.sh
@@ -36,6 +36,8 @@ if [ ! -f scripts/deploy.sh ]; then
 	exit 1
 fi
 eval "$(sed -n '/^deploy_run() {/,/^}/p' scripts/deploy.sh)"
+eval "$(sed -n '/^_detect_cluster() {/,/^}/p' scripts/deploy.sh)"
+eval "$(sed -n '/^_detect_platform() {/,/^}/p' scripts/deploy.sh)"
 if ! type deploy_run >/dev/null 2>&1; then
 	echo "FATAL: could not extract deploy_run() from scripts/deploy.sh" >&2
 	exit 1
@@ -43,7 +45,7 @@ fi
 
 # --- fake ABA_ROOT with stub sub-scripts + PATH-stubbed make ------------------
 _root="$_tmp/aba"
-mkdir -p "$_root/scripts" "$_root/mirror" "$_root/mycluster" "$_tmp/bin" "$_tmp/runner"
+mkdir -p "$_root/scripts" "$_root/mirror" "$_root/mycluster" "$_root/site" "$_tmp/bin" "$_tmp/runner"
 : > "$_root/mycluster/cluster.conf"
 export ABA_ROOT="$_root"
 export RUN_ONCE_DIR="$_tmp/runner"
@@ -159,6 +161,46 @@ _hasnot "fix-resume run 1: iso not reached (load failed)" "$DEPLOY_LOG" 'myclust
 ( deploy_run "$_root" "site" "mycluster" "vmw" ) >/dev/null 2>&1
 _has "fix-resume run 2: previously-failed load retried, iso reached" "$DEPLOY_LOG" 'mycluster iso'
 _has "fix-resume run 2: pipeline completes through day2"             "$DEPLOY_LOG" 'day2'
+
+# --- Test 6c: --restart forces a fresh re-run of completed steps --------------
+echo "--- --restart re-runs completed steps ---"
+_reset_state
+( deploy_run "$_root" "site" "mycluster" "vmw" ) >/dev/null 2>&1
+_r1=$(wc -l < "$DEPLOY_LOG")
+( DEPLOY_RESTART=1 deploy_run "$_root" "site" "mycluster" "vmw" ) >/dev/null 2>&1
+_r2=$(wc -l < "$DEPLOY_LOG")
+[ "$_r1" -gt 0 ] && [ "$_r2" -gt "$_r1" ] \
+	&& test_pass "--restart clears cached state and re-runs steps: $_r1 -> $_r2" \
+	|| test_fail "--restart" "expected growth; $_r1 -> $_r2"
+
+# --- Test 6d: config-import is skipped when there is no site payload -----------
+echo "--- no site payload: config-import skipped, pipeline proceeds ---"
+_root2="$_tmp/aba2"
+mkdir -p "$_root2/scripts" "$_root2/mirror" "$_root2/standalone"
+: > "$_root2/standalone/cluster.conf"
+cp "$_root/scripts/config-import.sh" "$_root2/scripts/config-import.sh"
+cp "$_root/scripts/day2.sh" "$_root2/scripts/day2.sh"
+_LOG2="$_tmp/order2.log"; : > "$_LOG2"
+( export DEPLOY_LOG="$_LOG2" RUN_ONCE_DIR="$_tmp/runner2"; mkdir -p "$_tmp/runner2"; deploy_run "$_root2" "site" "standalone" "vmw" ) >/dev/null 2>&1
+if grep -q 'config-import' "$_LOG2"; then
+	test_fail "config-import skipped w/o site" "config-import ran despite no site dir"
+else
+	test_pass "config-import skipped when no site payload (deploys in place)"
+fi
+grep -q 'mirror install' "$_LOG2" && test_pass "pipeline proceeds without a site payload" || test_fail "no-site pipeline" "mirror install not reached"
+
+# --- Test 6e: multiple clusters abort with the correct message (finding [5]) ---
+echo "--- multiple clusters -> accurate abort ---"
+_root3="$_tmp/aba3"
+mkdir -p "$_root3/scripts" "$_root3/mirror" "$_root3/c1" "$_root3/c2"
+: > "$_root3/c1/cluster.conf"; : > "$_root3/c2/cluster.conf"
+cp "$_root/scripts/config-import.sh" "$_root3/scripts/config-import.sh"
+cp "$_root/scripts/day2.sh" "$_root3/scripts/day2.sh"
+_ML="$_tmp/ml.out"
+( export DEPLOY_LOG="$_tmp/order3.log" RUN_ONCE_DIR="$_tmp/runner3"; mkdir -p "$_tmp/runner3"; deploy_run "$_root3" "site" "" "vmw" ) >"$_ML" 2>&1
+_mlrc=$?
+[ "$_mlrc" -ne 0 ] && test_pass "multiple clusters aborts (non-zero, not a silent no-op)" || test_fail "multi-cluster abort" "expected non-zero exit"
+grep -qi 'multiple clusters' "$_ML" && test_pass "multi-cluster error is accurate (not the misleading 'none found')" || test_fail "multi-cluster msg" "got: $(tail -1 "$_ML")"
 
 # --- Test 7: CLI dispatch wiring ----------------------------------------------
 echo "--- dispatch wiring ---"

--- a/test/func/test-deploy.sh
+++ b/test/func/test-deploy.sh
@@ -222,6 +222,53 @@ grep -q 'unknown option' "$REPO_ROOT/scripts/deploy.sh" \
 grep -q '"$home/$site"' "$REPO_ROOT/scripts/deploy.sh" \
 	&& test_pass "cluster auto-detect falls back to the site payload (works before import)" \
 	|| test_fail "detect fallback" "no site-payload fallback in _detect_cluster"
+grep -q 'unexpected argument' "$REPO_ROOT/scripts/deploy.sh" \
+	&& test_pass "deploy rejects stray positionals (does not silently deploy a different cluster)" \
+	|| test_fail "positional guard" "no '*) abort' in deploy arg loop"
+grep -qE '\-n\|--name\)' "$REPO_ROOT/scripts/deploy.sh" \
+	&& test_pass "deploy accepts aba's '-n <name>' cluster syntax" \
+	|| test_fail "name syntax" "no -n/--name handling"
+
+# --- Test 9: --restart is atomic (interrupted restart cannot skip later steps) -
+echo "--- --restart atomicity (interrupted restart -> plain resume) ---"
+_reset_state
+( deploy_run "$_root" "site" "mycluster" "vmw" ) >/dev/null 2>&1          # run1: full deploy populates cache
+: > "$DEPLOY_LOG"
+( export DEPLOY_RESTART=1 MAKE_FAIL_ON="mirror load"; deploy_run "$_root" "site" "mycluster" "vmw" ) >/dev/null 2>&1  # run2: restart aborts at load
+: > "$DEPLOY_LOG"
+( deploy_run "$_root" "site" "mycluster" "vmw" ) >/dev/null 2>&1          # run3: plain resume (as the abort tells the user)
+_has "restart-interrupted resume re-runs iso"      "$DEPLOY_LOG" 'mycluster iso'
+_has "restart-interrupted resume re-runs install"  "$DEPLOY_LOG" 'mycluster install'
+_has "restart-interrupted resume re-runs day2"     "$DEPLOY_LOG" 'day2'
+
+# --- Test 9b: --restart clears the bare-metal boot marker (pauses once again) --
+echo "--- --restart clears the boot marker (fresh bm re-deploy) ---"
+_reset_state
+( deploy_run "$_root" "site" "mycluster" "bm" ) >/dev/null 2>&1           # pause
+( deploy_run "$_root" "site" "mycluster" "bm" ) >/dev/null 2>&1           # resume -> complete (marker latched)
+: > "$DEPLOY_LOG"
+( DEPLOY_RESTART=1 deploy_run "$_root" "site" "mycluster" "bm" ) >/dev/null 2>&1   # fresh restart
+_has    "bm restart: rebuilds the ISO"                    "$DEPLOY_LOG" 'mycluster iso'
+_hasnot "bm restart: pauses again (no straight-through to monitor)" "$DEPLOY_LOG" 'mycluster mon'
+[ -f "$_root/mycluster/.aba-deploy-await-boot" ] \
+	&& test_pass "bm restart: boot marker re-created at the (single) pause" \
+	|| test_fail "bm restart marker" "marker missing after restart pause"
+
+# --- Test 9c: an explicit --site that does not exist aborts (no silent in-place) -
+echo "--- explicit --site missing -> abort ---"
+_reset_state
+_ES="$_tmp/es.out"
+( deploy_run "$_root" "no-such-site" "mycluster" "bm" 1 ) >"$_ES" 2>&1
+_esrc=$?
+[ "$_esrc" -ne 0 ] && grep -qi 'not found' "$_ES" \
+	&& test_pass "explicit --site to a missing dir aborts (does not deploy in place)" \
+	|| test_fail "explicit --site" "expected abort, got rc=$_esrc: $(tail -1 "$_ES")"
+# a NON-explicit missing site still proceeds in place (abort is gated on explicit)
+: > "$DEPLOY_LOG"
+( deploy_run "$_root" "no-such-site" "mycluster" "bm" "" ) >/dev/null 2>&1
+grep -q 'mirror install' "$DEPLOY_LOG" \
+	&& test_pass "non-explicit missing site still deploys in place (no abort)" \
+	|| test_fail "implicit site" "did not proceed in place"
 
 echo
 echo "=== Results: $pass passed, $fail failed ==="


### PR DESCRIPTION
Adds four vendor-neutral, source-agnostic features that make a fully air-gapped OpenShift install a single command. `aba deploy` orchestrates the existing steps (config import, mirror install/load, ISO, monitor, day2) as an idempotent, resumable pipeline that pauses for manual node boot and resumes on re-run. `aba config import <dir>` places prebuilt configs verbatim and pins the regeneration guards so aba never re-templates over them, and `aba bundle --complete` embeds a `site/` config payload so one archive crosses the air gap. `day2-custom-manifests/` gains optional numbered waves applied in numeric order with a per-wave `.wait` gate, while the existing flat layout keeps working unchanged. Functional tests live under `test/func/`.
